### PR TITLE
perf: use dist profile for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --profile dist --target ${{ matrix.target }}
 
       - name: Prepare artifact
         shell: bash
@@ -81,7 +81,7 @@ jobs:
           if [[ "${{ matrix.platform }}" == "win32" ]]; then
             exe=".exe"
           fi
-          cp target/${{ matrix.target }}/release/foundryup${exe} foundryup_${{ matrix.platform }}_${{ matrix.arch }}
+          cp target/${{ matrix.target }}/dist/foundryup${exe} foundryup_${{ matrix.platform }}_${{ matrix.arch }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ strip = "debuginfo"
 panic = "abort"
 codegen-units = 16
 
+[profile.dist]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
 [build-dependencies]
 vergen-gitcl = { version = "1", features = ["build", "rustc"] }
 


### PR DESCRIPTION
Add a dist profile that inherits from release but uses fat LTO and a single codegen unit for smaller binaries. Update the release workflow to build with this profile.

Copied from foundry-rs/foundry.