### PR TITLE
chore: remove tempo fork support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,9 +56,9 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub cargo_features: Option<String>,
 
-    /// Install binaries for a specific network (e.g., tempo)
-    #[arg(short = 'n', long)]
-    pub network: Option<Network>,
+    /// [deprecated] Install binaries for a specific network
+    #[arg(short = 'n', long, hide = true)]
+    pub network: Option<String>,
 
     /// Skip SHA verification (INSECURE)
     #[arg(short = 'f', long)]
@@ -75,11 +75,6 @@ pub(crate) struct Cli {
     /// Generate shell completions
     #[arg(long, value_name = "SHELL")]
     pub completions: Option<clap_complete::Shell>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub(crate) enum Network {
-    Tempo,
 }
 
 pub(crate) fn print_completions(shell: clap_complete::Shell) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{cli::Network, say};
+use crate::say;
 use eyre::Result;
 use fs_err as fs;
 use std::path::{Path, PathBuf};
@@ -26,7 +26,7 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn new(network: Option<Network>) -> Result<Self> {
+    pub(crate) fn new() -> Result<Self> {
         let base_dir =
             std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from).or_else(home::home_dir);
 
@@ -39,9 +39,7 @@ impl Config {
         let versions_dir = foundry_dir.join("versions");
         let bin_dir = foundry_dir.join("bin");
         let man_dir = foundry_dir.join("share/man/man1");
-        let network = NetworkConfig::for_network(network);
-
-        Ok(Self { foundry_dir, versions_dir, bin_dir, man_dir, network })
+        Ok(Self { foundry_dir, versions_dir, bin_dir, man_dir, network: NetworkConfig::FOUNDRY })
     }
 
     pub(crate) fn ensure_dirs(&self) -> Result<()> {
@@ -135,7 +133,7 @@ pub(crate) struct NetworkConfig {
 }
 
 impl NetworkConfig {
-    const FOUNDRY: Self = Self {
+    pub(crate) const FOUNDRY: Self = Self {
         repo: "foundry-rs/foundry",
         bins: &["forge", "cast", "anvil", "chisel"],
         archive_prefix: "foundry",
@@ -143,20 +141,4 @@ impl NetworkConfig {
         display_name: "foundry",
         has_attestation: true,
     };
-
-    const TEMPO: Self = Self {
-        repo: "tempoxyz/tempo-foundry",
-        bins: &["forge", "cast"],
-        archive_prefix: "foundry",
-        default_version: "nightly",
-        display_name: "tempo-foundry",
-        has_attestation: false,
-    };
-
-    fn for_network(network: Option<Network>) -> Self {
-        match network {
-            Some(Network::Tempo) => Self::TEMPO,
-            None => Self::FOUNDRY,
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,11 @@ async fn run(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    let config = Arc::new(Config::new(cli.network)?);
+    if cli.network.is_some() {
+        warn!("the --network flag is deprecated and will be removed in a future release. Tempo is now included in the default Foundry installation.");
+    }
+
+    let config = Arc::new(Config::new()?);
     config.migrate_legacy_versions()?;
 
     if cli.update {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,9 @@ async fn run(cli: Cli) -> Result<()> {
     }
 
     if cli.network.is_some() {
-        warn!("the --network flag is deprecated and will be removed in a future release. Tempo is now included in the default Foundry installation.");
+        warn!(
+            "the --network flag is deprecated and will be removed in a future release. Tempo is now included in the default Foundry installation."
+        );
     }
 
     let config = Arc::new(Config::new()?);

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -2,7 +2,6 @@ use snapbox::{cmd::Command, str};
 use std::{env::consts::EXE_SUFFIX, path::Path};
 
 const BINS: &[&str] = &["forge", "cast", "anvil", "chisel"];
-const TEMPO_BINS: &[&str] = &["forge", "cast"];
 
 mod installer_script;
 mod self_update;
@@ -74,11 +73,6 @@ Options:
 
       --cargo-features <CARGO_FEATURES>
           Cargo features to enable for building
-
-  -n, --network <NETWORK>
-          Install binaries for a specific network (e.g., tempo)
-          
-          [possible values: tempo]
 
   -f, --force
           Skip SHA verification (INSECURE)
@@ -287,28 +281,3 @@ fn reinstall_uses_cache() {
 "#]]);
 }
 
-#[test]
-fn install_tempo_nightly() {
-    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
-    let foundry_dir = temp_dir.path().join(".foundry");
-
-    foundryup()
-        .env("FOUNDRY_DIR", &foundry_dir)
-        .args(["--network", "tempo"])
-        .assert()
-        .success()
-        .stderr_eq(str![[r#"
-...
-[..]installing tempo-foundry[..]
-...
-[..]done!
-...
-"#]]);
-
-    for &bin in TEMPO_BINS {
-        let name = format!("{bin}{EXE_SUFFIX}");
-        assert!(foundry_dir.join("bin").join(&name).exists(), "{name} does not exist");
-    }
-
-    run_forge_test(&foundry_dir, temp_dir.path());
-}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -280,4 +280,3 @@ fn reinstall_uses_cache() {
 ...
 "#]]);
 }
-


### PR DESCRIPTION
Tempo is now fully upstream in the main Foundry repo, so the separate network handling is no longer needed.