### PR TITLE
feat: resolve version channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Build
-        run: cargo build --target ${{ matrix.target }}
+        run: |
+          cargo clean -p foundryup --target ${{ matrix.target }}
+          cargo build --target ${{ matrix.target }}
       - name: Test
         run: cargo nextest run --no-fail-fast --target ${{ matrix.target }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-targets: false
+          prefix-key: v1-rust
       - uses: taiki-e/install-action@nextest
       - name: Build
-        run: |
-          cargo clean -p foundryup --target ${{ matrix.target }}
-          cargo build --target ${{ matrix.target }}
+        run: cargo build --target ${{ matrix.target }}
       - name: Test
         run: cargo nextest run --no-fail-fast --target ${{ matrix.target }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: cargo build --target ${{ matrix.target }}
       - name: Test
         run: cargo nextest run --no-fail-fast --target ${{ matrix.target }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   typos:
     runs-on: ubuntu-latest

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{CommandFactory, Parser};
 ///
 /// By default, the latest stable version is installed from built binaries.
 #[derive(Debug, Parser)]
-#[command(name = "foundryup", version = crate::config::LONG_VERSION, about)]
+#[command(name = "foundryup", version = crate::config::LONG_VERSION, about, disable_version_flag = true)]
 pub(crate) struct Cli {
     /// Update foundryup to the latest version
     #[arg(short = 'U', long = "update")]
@@ -75,6 +75,10 @@ pub(crate) struct Cli {
     /// Generate shell completions
     #[arg(long, value_name = "SHELL")]
     pub completions: Option<clap_complete::Shell>,
+
+    /// Print version
+    #[arg(short = 'V', short_alias = 'v', long = "version", action = clap::ArgAction::Version)]
+    pub version_flag: Option<bool>,
 }
 
 pub(crate) fn print_completions(shell: clap_complete::Shell) {

--- a/src/download.rs
+++ b/src/download.rs
@@ -28,6 +28,24 @@ impl PartialEq<&str> for GitHubHosts {
     }
 }
 
+/// Returns a GitHub token from the environment, if set, used to authenticate
+/// `api.github.com` requests so they use the higher authenticated rate limit.
+/// Checks `GITHUB_TOKEN` then `GH_TOKEN`; empty values are ignored.
+fn github_token() -> Option<String> {
+    ["GITHUB_TOKEN", "GH_TOKEN"]
+        .into_iter()
+        .find_map(|var| std::env::var(var).ok().filter(|t| !t.is_empty()))
+}
+
+/// Whether `url` points at the GitHub REST API over HTTPS, used to gate token
+/// attachment. Matches the origin exactly (scheme + host + port) so a token is
+/// never sent to lookalike hosts like `api.github.com.evil.com`.
+fn is_github_api_url(url: &reqwest::Url) -> bool {
+    url.scheme() == "https"
+        && url.host_str().is_some_and(|host| host.eq_ignore_ascii_case("api.github.com"))
+        && url.port_or_known_default() == Some(443)
+}
+
 pub(crate) struct Downloader {
     client: reqwest::Client,
 }
@@ -48,6 +66,7 @@ impl Downloader {
             });
 
         let client = reqwest::Client::builder()
+            .https_only(true)
             .user_agent(concat!("foundryup/", env!("CARGO_PKG_VERSION")))
             .retry(retry)
             .build()
@@ -56,8 +75,17 @@ impl Downloader {
     }
 
     async fn send(&self, url: &str) -> Result<reqwest::Response> {
-        let response =
-            self.client.get(url).send().await.wrap_err_with(|| format!("failed to GET {url}"))?;
+        let parsed = reqwest::Url::parse(url).wrap_err_with(|| format!("invalid URL {url}"))?;
+        // Only attach the token to GitHub API requests, never to release-download
+        // CDN hosts. reqwest also strips it on cross-host redirects.
+        let is_github_api = is_github_api_url(&parsed);
+        let mut request = self.client.get(parsed);
+        if is_github_api {
+            if let Some(token) = github_token() {
+                request = request.bearer_auth(token);
+            }
+        }
+        let response = request.send().await.wrap_err_with(|| format!("failed to GET {url}"))?;
         if !response.status().is_success() {
             bail!("failed to download {url}: HTTP {}", response.status());
         }
@@ -175,6 +203,21 @@ mod tests {
         for code in [200, 301, 400, 401, 404, 410] {
             assert!(!is_retryable_status(reqwest::StatusCode::from_u16(code).unwrap()));
         }
+    }
+
+    #[test]
+    fn github_api_url_gate_only_matches_exact_origin() {
+        let api = |u: &str| is_github_api_url(&reqwest::Url::parse(u).unwrap());
+        // Token is attached only for the exact api.github.com HTTPS origin.
+        assert!(api("https://api.github.com/repos/x/y/releases/latest"));
+        assert!(api("https://API.GITHUB.COM/repos/x/y"));
+        assert!(api("https://api.github.com:443/repos/x/y"));
+        // Lookalikes, userinfo tricks, other hosts and schemes are rejected.
+        assert!(!api("https://api.github.com.evil.com/"));
+        assert!(!api("https://api.github.com@evil.com/"));
+        assert!(!api("http://api.github.com/"));
+        assert!(!api("https://github.com/foundry-rs/foundry/releases/download/v1/x"));
+        assert!(!api("https://objects.githubusercontent.com/x"));
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -586,7 +586,8 @@ in your 'PATH' to allow the newly installed version to take precedence!
 /// used for the archive files and asset names.
 ///
 /// The `latest` and `stable` channels are resolved to the newest non-prerelease
-/// tag via the GitHub API; everything else is normalized offline.
+/// tag via the GitHub API. The `nightly` channel is resolved to the newest
+/// nightly release tag. Everything else is normalized offline.
 pub(crate) async fn resolve_version_and_tag(
     downloader: &Downloader,
     repo: &str,
@@ -597,6 +598,11 @@ pub(crate) async fn resolve_version_and_tag(
         let tag = fetch_latest_release_tag(downloader, repo).await?;
         say!("resolved release tag: {tag}");
         Ok((tag.clone(), tag))
+    } else if version == "nightly" {
+        say!("fetching latest nightly release tags from {repo}...");
+        let tag = fetch_latest_nightly_release_tag(downloader, repo).await?;
+        say!("resolved nightly release tag: {tag}");
+        Ok(("nightly".to_string(), tag))
     } else {
         Ok(normalize_version(version))
     }
@@ -615,6 +621,33 @@ async fn fetch_latest_release_tag(downloader: &Downloader, repo: &str) -> Result
         Some(tag) => Ok(tag.to_string()),
         None => bail!("could not find a latest release tag for {repo}"),
     }
+}
+
+/// Fetches the newest nightly release tag for `repo` via the GitHub API.
+async fn fetch_latest_nightly_release_tag(downloader: &Downloader, repo: &str) -> Result<String> {
+    let url = format!("https://api.github.com/repos/{repo}/releases");
+    let body = downloader
+        .download_to_string(&url)
+        .await
+        .wrap_err("failed to fetch release tags from GitHub API")?;
+    latest_nightly_release_tag(&body, repo)
+}
+
+fn latest_nightly_release_tag(json: &str, repo: &str) -> Result<String> {
+    let json: serde_json::Value = serde_json::from_str(json)?;
+    let releases =
+        json.as_array().ok_or_else(|| eyre::eyre!("invalid release tags response for {repo}"))?;
+
+    releases
+        .iter()
+        .filter_map(|release| {
+            let tag = release["tag_name"].as_str()?;
+            let published_at = release["published_at"].as_str()?;
+            tag.starts_with("nightly-").then_some((published_at, tag))
+        })
+        .max_by_key(|(published_at, _tag)| *published_at)
+        .map(|(_published_at, tag)| tag.to_string())
+        .ok_or_else(|| eyre::eyre!("could not find a nightly release tag for {repo}"))
 }
 
 fn normalize_version(version: &str) -> (String, String) {
@@ -645,6 +678,44 @@ fn rustflags() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn latest_nightly_release_tag_selects_newest_published_at() {
+        let json = r#"[
+            {"tag_name": "nightly-old", "published_at": "2026-05-01T00:00:00Z"},
+            {"tag_name": "v1.5.0", "published_at": "2026-06-01T00:00:00Z"},
+            {"tag_name": "nightly-new", "published_at": "2026-05-03T00:00:00Z"},
+            {"tag_name": "nightly-middle", "published_at": "2026-05-02T00:00:00Z"}
+        ]"#;
+
+        let tag = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap();
+
+        assert_eq!(tag, "nightly-new");
+    }
+
+    #[test]
+    fn latest_nightly_release_tag_ignores_non_nightly_releases() {
+        let json = r#"[
+            {"tag_name": "v2.0.0", "published_at": "2026-06-01T00:00:00Z"},
+            {"tag_name": "stable", "published_at": "2026-06-02T00:00:00Z"},
+            {"tag_name": "nightly-abc", "published_at": "2026-05-01T00:00:00Z"}
+        ]"#;
+
+        let tag = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap();
+
+        assert_eq!(tag, "nightly-abc");
+    }
+
+    #[test]
+    fn latest_nightly_release_tag_errors_when_no_nightly_exists() {
+        let json = r#"[
+            {"tag_name": "v2.0.0", "published_at": "2026-06-01T00:00:00Z"}
+        ]"#;
+
+        let err = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap_err();
+
+        assert!(err.to_string().contains("could not find a nightly release tag"));
+    }
 
     #[test]
     fn attestation_de() {

--- a/src/install.rs
+++ b/src/install.rs
@@ -29,15 +29,20 @@ pub(crate) async fn run(config: &Config, args: &Cli) -> Result<()> {
 }
 
 async fn install_prebuilt(config: &Config, args: &Cli) -> Result<()> {
-    let (version, tag) =
-        normalize_version(args.version.as_deref().unwrap_or(config.network.default_version));
-
     let repo = config.network.repo;
+
+    let downloader = Downloader::new()?;
+
+    let (version, tag) = resolve_version_and_tag(
+        &downloader,
+        repo,
+        args.version.as_deref().unwrap_or(config.network.default_version),
+    )
+    .await?;
 
     say!("installing {} (version {version}, tag {tag})", config.network.display_name);
 
     let target = Target::detect(args.platform.as_deref(), args.arch.as_deref())?;
-    let downloader = Downloader::new()?;
 
     let release_url =
         format!("https://github.com/{}/releases/download/{tag}/", config.network.repo);
@@ -511,12 +516,22 @@ pub(crate) fn list(config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Normalizes `version` and activates the matching installed version directory,
+/// so e.g. `1.5.0` resolves to the `v1.5.0` directory.
+pub(crate) async fn use_version_resolved(config: &Config, repo: &str, version: &str) -> Result<()> {
+    let downloader = Downloader::new()?;
+    let (_version, tag) = resolve_version_and_tag(&downloader, repo, version).await?;
+    use_version(config, repo, &tag)
+}
+
 pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<()> {
     let version_dir = config.version_dir(repo, version);
 
     if !version_dir.exists() {
         bail!("version {version} not installed for {repo}");
     }
+
+    fs::create_dir_all(&config.bin_dir)?;
 
     for bin in config.network.bins {
         let bin_name = bin_name(bin);
@@ -564,6 +579,42 @@ in your 'PATH' to allow the newly installed version to take precedence!
     }
 
     Ok(())
+}
+
+/// Resolves a requested version string to its `(version, tag)` pair, where `tag`
+/// is the concrete GitHub release tag to download from and `version` is the name
+/// used for the archive files and asset names.
+///
+/// The `latest` and `stable` channels are resolved to the newest non-prerelease
+/// tag via the GitHub API; everything else is normalized offline.
+pub(crate) async fn resolve_version_and_tag(
+    downloader: &Downloader,
+    repo: &str,
+    version: &str,
+) -> Result<(String, String)> {
+    if version == "latest" || version == "stable" {
+        say!("fetching latest release tag from {repo}...");
+        let tag = fetch_latest_release_tag(downloader, repo).await?;
+        say!("resolved release tag: {tag}");
+        Ok((tag.clone(), tag))
+    } else {
+        Ok(normalize_version(version))
+    }
+}
+
+/// Fetches the newest non-prerelease release tag for `repo` via the GitHub API.
+async fn fetch_latest_release_tag(downloader: &Downloader, repo: &str) -> Result<String> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/latest");
+    let body = downloader
+        .download_to_string(&url)
+        .await
+        .wrap_err("failed to fetch release tags from GitHub API")?;
+    let json: serde_json::Value = serde_json::from_str(&body)?;
+    let tag = json["tag_name"].as_str().filter(|s| !s.is_empty());
+    match tag {
+        Some(tag) => Ok(tag.to_string()),
+        None => bail!("could not find a latest release tag for {repo}"),
+    }
 }
 
 fn normalize_version(version: &str) -> (String, String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn run(cli: Cli) -> Result<()> {
     if cli.list {
         install::list(&config)?;
     } else if let Some(ref version) = cli.use_version {
-        install::use_version(&config, config.network.repo, version)?;
+        install::use_version_resolved(&config, config.network.repo, version).await?;
     } else {
         print_banner();
         process::check_bins_in_use(&config)?;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -88,11 +88,11 @@ Options:
           
           [possible values: bash, elvish, fish, powershell, zsh]
 
-  -h, --help
-          Print help (see a summary with '-h')
-
   -V, --version
           Print version
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 "#]]);
 }
@@ -100,6 +100,21 @@ Options:
 #[test]
 fn version() {
     foundryup().arg("--version").assert().success().stdout_eq(str![[r#"
+foundryup [..]
+"#]]);
+}
+
+#[test]
+fn version_short() {
+    foundryup().arg("-V").assert().success().stdout_eq(str![[r#"
+foundryup [..]
+"#]]);
+}
+
+// `-v` is an alias for `--version`.
+#[test]
+fn version_short_alias() {
+    foundryup().arg("-v").assert().success().stdout_eq(str![[r#"
 foundryup [..]
 "#]]);
 }
@@ -141,6 +156,59 @@ fn use_nonexistent_version() {
 [..]version nonexistent-version not installed[..]
 ...
 "#]]);
+}
+
+// `--use` normalizes a bare semver (e.g. `1.5.0`) to the `v1.5.0` directory.
+#[test]
+fn use_version_normalizes_bare_semver() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.5.0");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    for bin in BINS {
+        let bin_path = version_dir.join(format!("{bin}{EXE_SUFFIX}"));
+        std::fs::write(&bin_path, "fake binary").unwrap();
+    }
+
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "1.5.0"])
+        .assert()
+        .success()
+        .stderr_eq(str![[r#"
+...
+[..]use - forge[..]
+...
+"#]]);
+
+    for &bin in BINS {
+        let name = format!("{bin}{EXE_SUFFIX}");
+        assert!(foundry_dir.join("bin").join(&name).exists(), "{name} was not activated");
+    }
+}
+
+// On unix, `--use` activates a version by symlinking it into the bin dir.
+#[cfg(unix)]
+#[test]
+fn use_version_creates_symlink_on_unix() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.5.0");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    for bin in BINS {
+        std::fs::write(version_dir.join(bin), "fake binary").unwrap();
+    }
+
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).args(["--use", "1.5.0"]).assert().success();
+
+    for &bin in BINS {
+        let dest = foundry_dir.join("bin").join(bin);
+        let meta = std::fs::symlink_metadata(&dest).unwrap();
+        assert!(meta.file_type().is_symlink(), "{bin} should be a symlink");
+        assert_eq!(std::fs::read_link(&dest).unwrap(), version_dir.join(bin));
+    }
 }
 
 #[test]
@@ -227,6 +295,11 @@ foundryup: - chisel [..]
 #[test]
 fn install_stable() {
     test_install("stable");
+}
+// `latest` resolves to the newest non-prerelease tag via the GitHub API.
+#[test]
+fn install_latest() {
+    test_install("latest");
 }
 #[test]
 fn install_nightly() {

--- a/tests/it/self_update.rs
+++ b/tests/it/self_update.rs
@@ -13,8 +13,22 @@ fn update_flag_help() {
 #[test]
 fn update_checks_for_updates() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let exe_dir = temp_dir.path().join("exe");
+    let foundry_dir = temp_dir.path().join("foundry");
+    std::fs::create_dir_all(&exe_dir).unwrap();
 
-    foundryup().env("FOUNDRY_DIR", temp_dir.path()).arg("-U").assert().stderr_eq(str![[r#"
+    // `-U` self-replaces the running binary. Run a copy (kept separate from
+    // FOUNDRY_DIR) so the shared Cargo test binary invoked by every other test
+    // via `cargo_bin!` is never clobbered under nextest parallelism.
+    let bin = exe_dir.join(format!("foundryup{EXE_SUFFIX}"));
+    std::fs::copy(snapbox::cmd::cargo_bin!("foundryup"), &bin).unwrap();
+
+    Command::new(&bin)
+        .env("NO_COLOR", "1")
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .arg("-U")
+        .assert()
+        .stderr_eq(str![[r#"
 ...
 foundryup: checking for updates...
 ...


### PR DESCRIPTION
Brings `foundryup` closer to legacy parity for version resolution and version reporting.

Changes included:
- Resolve `latest`/`stable` through the GitHub API instead of treating them as literal release tags.
- Resolve `nightly` to the newest `nightly-*` release tag.
- Normalize bare semver inputs for `--use`, e.g. `1.5.0` -> `v1.5.0`.
- Support `-v` as a version flag alias.
- Authenticate GitHub API requests with `GITHUB_TOKEN`/`GH_TOKEN` when available to avoid rate limits.
- Add tests for channel resolution, semver normalization, version flags, and self-update behavior.

Part of OSS-334.
