### PR TITLE
fix: emit --list to stdout and honor FOUNDRYUP_MAX_RETRIES

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use std::{io::Write, path::Path};
 
 /// Default number of retries (after the initial attempt) for transient HTTP
-/// failures, used when `FOUNDRYUP_MAX_RETRIES` is unset or unparseable.
+/// failures, used when `FOUNDRYUP_MAX_RETRIES` is unset or unparsable.
 const DEFAULT_MAX_RETRIES: u32 = 5;
 
 /// Number of retries for transient HTTP failures, honoring the

--- a/src/download.rs
+++ b/src/download.rs
@@ -260,6 +260,38 @@ mod tests {
     }
 
     #[test]
+    fn max_retries_honors_env_var() {
+        // Single test so the process-global env var can't race across threads.
+        let key = "FOUNDRYUP_MAX_RETRIES";
+        let original = std::env::var_os(key);
+
+        // Unset falls back to the default.
+        unsafe { std::env::remove_var(key) };
+        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
+
+        // A custom value (with surrounding whitespace) is parsed.
+        unsafe { std::env::set_var(key, " 9 ") };
+        assert_eq!(max_retries(), 9);
+
+        // Zero is honored (disables retries).
+        unsafe { std::env::set_var(key, "0") };
+        assert_eq!(max_retries(), 0);
+
+        // Unparsable values fall back to the default.
+        unsafe { std::env::set_var(key, "not-a-number") };
+        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
+
+        // Negative values aren't valid u32 and fall back to the default.
+        unsafe { std::env::set_var(key, "-1") };
+        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
+
+        match original {
+            Some(val) => unsafe { std::env::set_var(key, val) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    #[test]
     fn github_hosts_scope_matches_github_cdns() {
         assert!(GitHubHosts == "github.com");
         assert!(GitHubHosts == "api.github.com");

--- a/src/download.rs
+++ b/src/download.rs
@@ -260,38 +260,6 @@ mod tests {
     }
 
     #[test]
-    fn max_retries_honors_env_var() {
-        // Single test so the process-global env var can't race across threads.
-        let key = "FOUNDRYUP_MAX_RETRIES";
-        let original = std::env::var_os(key);
-
-        // Unset falls back to the default.
-        unsafe { std::env::remove_var(key) };
-        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
-
-        // A custom value (with surrounding whitespace) is parsed.
-        unsafe { std::env::set_var(key, " 9 ") };
-        assert_eq!(max_retries(), 9);
-
-        // Zero is honored (disables retries).
-        unsafe { std::env::set_var(key, "0") };
-        assert_eq!(max_retries(), 0);
-
-        // Unparsable values fall back to the default.
-        unsafe { std::env::set_var(key, "not-a-number") };
-        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
-
-        // Negative values aren't valid u32 and fall back to the default.
-        unsafe { std::env::set_var(key, "-1") };
-        assert_eq!(max_retries(), DEFAULT_MAX_RETRIES);
-
-        match original {
-            Some(val) => unsafe { std::env::set_var(key, val) },
-            None => unsafe { std::env::remove_var(key) },
-        }
-    }
-
-    #[test]
     fn github_hosts_scope_matches_github_cdns() {
         assert!(GitHubHosts == "github.com");
         assert!(GitHubHosts == "api.github.com");

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,8 +5,22 @@ use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
 use std::{io::Write, path::Path};
 
-/// Number of retries (after the initial attempt) for transient HTTP failures.
-const MAX_RETRIES: u32 = 5;
+/// Default number of retries (after the initial attempt) for transient HTTP
+/// failures, used when `FOUNDRYUP_MAX_RETRIES` is unset or unparseable.
+const DEFAULT_MAX_RETRIES: u32 = 5;
+
+/// Number of retries for transient HTTP failures, honoring the
+/// `FOUNDRYUP_MAX_RETRIES` environment variable (matching the install script).
+///
+/// The script's `FOUNDRYUP_RETRY_DELAY` / `FOUNDRYUP_RETRY_MAX_TIME` are not
+/// supported here: reqwest's retry layer manages its own backoff and does not
+/// expose delay or total-time knobs.
+fn max_retries() -> u32 {
+    std::env::var("FOUNDRYUP_MAX_RETRIES")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(DEFAULT_MAX_RETRIES)
+}
 
 /// Transient HTTP statuses that may recover on retry (e.g. GitHub rate limiting
 /// or temporary outages). Other errors (e.g. 404) are treated as permanent.
@@ -56,7 +70,7 @@ impl Downloader {
         // otherwise block retries on a CLI that issues only a few requests.
         let retry = reqwest::retry::for_host(GitHubHosts)
             .no_budget()
-            .max_retries_per_request(MAX_RETRIES)
+            .max_retries_per_request(max_retries())
             .classify_fn(|req_rep| {
                 if req_rep.error().is_some() || req_rep.status().is_some_and(is_retryable_status) {
                     req_rep.retryable()

--- a/src/install.rs
+++ b/src/install.rs
@@ -3,7 +3,7 @@ use crate::{
     config::Config,
     download::{Downloader, compute_sha256, extract_tar_gz, extract_zip},
     platform::{Platform, Target},
-    say, warn,
+    say, tell, warn,
 };
 use eyre::{Result, WrapErr, bail};
 use fs_err as fs;
@@ -549,18 +549,18 @@ pub(crate) fn list(config: &Config) -> Result<()> {
                     let version_name = version_entry.file_name();
                     let version_name = version_name.to_string_lossy();
 
-                    say!("{owner_name}/{repo_name} {version_name}");
+                    tell!("{owner_name}/{repo_name} {version_name}");
 
                     for bin in bins {
                         let bin_path = version_path.join(bin_name(bin));
                         if bin_path.exists() {
                             match get_bin_version(&bin_path) {
-                                Ok(v) => say!("- {v}"),
-                                Err(_) => say!("- {bin} (unknown version)"),
+                                Ok(v) => tell!("- {v}"),
+                                Err(_) => tell!("- {bin} (unknown version)"),
                             }
                         }
                     }
-                    eprintln!();
+                    println!();
                 }
             }
         }
@@ -569,8 +569,8 @@ pub(crate) fn list(config: &Config) -> Result<()> {
             let bin_path = config.bin_path(bin);
             if bin_path.exists() {
                 match get_bin_version(&bin_path) {
-                    Ok(v) => say!("- {v}"),
-                    Err(_) => say!("- {bin} (unknown version)"),
+                    Ok(v) => tell!("- {v}"),
+                    Err(_) => tell!("- {bin} (unknown version)"),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,14 @@ macro_rules! say {
     };
 }
 
+/// Like [`say`], but writes to stdout instead of stderr.
+#[macro_export]
+macro_rules! tell {
+    ($($arg:tt)*) => {
+        println!("foundryup: {}", format_args!($($arg)*))
+    };
+}
+
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => {

--- a/tests/it/foundry_bins.rs
+++ b/tests/it/foundry_bins.rs
@@ -42,7 +42,7 @@ fn test_install(version: &str) {
 
     run_forge_test(&foundry_dir, temp_dir.path());
 
-    foundryup().env("FOUNDRY_DIR", &foundry_dir).arg("--list").assert().success().stderr_eq(str![
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).arg("--list").assert().success().stdout_eq(str![
         [r#"
 foundryup: foundry-rs/foundry [..]
 foundryup: - forge [..]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -225,6 +225,26 @@ fn list_empty() {
         .success();
 }
 
+// `--list` results are written to stdout.
+#[test]
+fn list_writes_to_stdout() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.0.0");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    for bin in BINS {
+        std::fs::write(version_dir.join(format!("{bin}{EXE_SUFFIX}")), "fake binary").unwrap();
+    }
+
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).arg("--list").assert().success().stdout_eq(str![
+        [r#"
+foundryup: foundry-rs/foundry v1.0.0
+...
+"#]
+    ]);
+}
+
 #[test]
 fn migrate_legacy_versions() {
     let temp_dir = tempfile::Builder::new().tempdir().unwrap();


### PR DESCRIPTION
`--list` now writes results to stdout (so they can be piped) instead of stderr. Network retries honor the `FOUNDRYUP_MAX_RETRIES` env var (default 5) instead of a hardcoded value; `FOUNDRYUP_RETRY_DELAY`/`FOUNDRYUP_RETRY_MAX_TIME` remain unsupported (the retry layer manages backoff internally).

Part of OSS-334