### PR TITLE
fix: restore legacy --use behavior for literal and custom-repo versions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,10 +4,11 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 
 # Run the install/use tests one at a time. They invoke `check_bins_in_use`,
 # which scans for running `forge`/`cast`/`anvil`/`chisel` processes globally, and
-# they also spawn those binaries themselves, so they must not run concurrently.
+# the `foundry_bins::` tests also spawn those binaries themselves, so they must
+# not run concurrently.
 [test-groups]
 foundry-bins = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'test(/^foundry_bins::/)'
+filter = 'test(/^foundry_bins::/) | test(/^use_version_/)'
 test-group = 'foundry-bins'

--- a/src/install.rs
+++ b/src/install.rs
@@ -659,19 +659,10 @@ fn is_resolvable_use_version(version: &str) -> bool {
     matches!(version, "latest" | "stable" | "nightly") || is_semver_like(version)
 }
 
-/// Whether `version` starts with a digit and has at least two `.` separators
-/// each followed by a digit (e.g. `1.5.0`, `1.5.0-rc1`, but not `123abc`).
+/// Whether `version` is a strict `major.minor.patch` semver version (e.g.
+/// `1.5.0`, `1.5.0-rc1`, but not `123abc` or `0xfoo-branch-release-1.2.3`).
 fn is_semver_like(version: &str) -> bool {
-    if !version.starts_with(|c: char| c.is_ascii_digit()) {
-        return false;
-    }
-    let bytes = version.as_bytes();
-    let dots_followed_by_digit = bytes
-        .iter()
-        .enumerate()
-        .filter(|&(i, &b)| b == b'.' && bytes.get(i + 1).is_some_and(|n| n.is_ascii_digit()))
-        .count();
-    dots_followed_by_digit >= 2
+    semver::Version::parse(version).is_ok()
 }
 
 pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<()> {
@@ -914,12 +905,14 @@ mod tests {
     fn semver_like_cases() {
         assert!(is_semver_like("1.5.0"));
         assert!(is_semver_like("1.5.0-rc1"));
-        assert!(is_semver_like("1.2.3.4"));
         assert!(is_semver_like("10.20.30"));
-        assert!(is_semver_like("1.a.2.3"));
-        assert!(is_semver_like("1.2.x.3"));
-        assert!(is_semver_like("1..2.3"));
-        assert!(is_semver_like("1.2.3."));
+        assert!(is_semver_like("1.5.0+build.1"));
+        // Not strict major.minor.patch semver -> treated verbatim.
+        assert!(!is_semver_like("1.2.3.4"));
+        assert!(!is_semver_like("1.a.2.3"));
+        assert!(!is_semver_like("1.2.x.3"));
+        assert!(!is_semver_like("1..2.3"));
+        assert!(!is_semver_like("1.2.3."));
         assert!(!is_semver_like("1.5"));
         assert!(!is_semver_like("1..2"));
         assert!(!is_semver_like("1.2."));
@@ -929,6 +922,9 @@ mod tests {
         assert!(!is_semver_like("v1.5.0"));
         assert!(!is_semver_like("nightly"));
         assert!(!is_semver_like("foundry-rs-branch-master"));
+        // Digit-prefixed custom build name with dotted numeric segments must not
+        // be mistaken for semver (regression for OSS-334 review).
+        assert!(!is_semver_like("0xfoo-branch-release-1.2.3"));
     }
 
     #[test]
@@ -940,6 +936,7 @@ mod tests {
         assert!(!is_resolvable_use_version("123abc"));
         assert!(!is_resolvable_use_version("nightly-abc123"));
         assert!(!is_resolvable_use_version("foundry-rs-pr-1"));
+        assert!(!is_resolvable_use_version("0xfoo-branch-release-1.2.3"));
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -579,12 +579,37 @@ pub(crate) fn list(config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Normalizes `version` and activates the matching installed version directory,
-/// so e.g. `1.5.0` resolves to the `v1.5.0` directory.
+/// Resolves channels and semver versions to a release tag; activates any other
+/// value verbatim, so `--use 123abc` looks up `123abc` rather than `v123abc`.
 pub(crate) async fn use_version_resolved(config: &Config, repo: &str, version: &str) -> Result<()> {
-    let downloader = Downloader::new()?;
-    let (_version, tag) = resolve_version_and_tag(&downloader, repo, version).await?;
+    let tag = if is_resolvable_use_version(version) {
+        let downloader = Downloader::new()?;
+        let (_version, tag) = resolve_version_and_tag(&downloader, repo, version).await?;
+        tag
+    } else {
+        version.to_string()
+    };
     use_version(config, repo, &tag)
+}
+
+/// Whether `version` is a channel or semver version that resolves to a tag.
+fn is_resolvable_use_version(version: &str) -> bool {
+    matches!(version, "latest" | "stable" | "nightly") || is_semver_like(version)
+}
+
+/// Whether `version` starts with a digit and has at least two `.` separators
+/// each followed by a digit (e.g. `1.5.0`, `1.5.0-rc1`, but not `123abc`).
+fn is_semver_like(version: &str) -> bool {
+    if !version.starts_with(|c: char| c.is_ascii_digit()) {
+        return false;
+    }
+    let bytes = version.as_bytes();
+    let dots_followed_by_digit = bytes
+        .iter()
+        .enumerate()
+        .filter(|&(i, &b)| b == b'.' && bytes.get(i + 1).is_some_and(|n| n.is_ascii_digit()))
+        .count();
+    dots_followed_by_digit >= 2
 }
 
 pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<()> {
@@ -821,6 +846,38 @@ mod tests {
         let err = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap_err();
 
         assert!(err.to_string().contains("could not find a nightly release tag"));
+    }
+
+    #[test]
+    fn semver_like_cases() {
+        assert!(is_semver_like("1.5.0"));
+        assert!(is_semver_like("1.5.0-rc1"));
+        assert!(is_semver_like("1.2.3.4"));
+        assert!(is_semver_like("10.20.30"));
+        assert!(is_semver_like("1.a.2.3"));
+        assert!(is_semver_like("1.2.x.3"));
+        assert!(is_semver_like("1..2.3"));
+        assert!(is_semver_like("1.2.3."));
+        assert!(!is_semver_like("1.5"));
+        assert!(!is_semver_like("1..2"));
+        assert!(!is_semver_like("1.2."));
+        assert!(!is_semver_like(".1.2.3"));
+        assert!(!is_semver_like("123abc"));
+        assert!(!is_semver_like("1.x.0"));
+        assert!(!is_semver_like("v1.5.0"));
+        assert!(!is_semver_like("nightly"));
+        assert!(!is_semver_like("foundry-rs-branch-master"));
+    }
+
+    #[test]
+    fn resolvable_use_version_cases() {
+        for channel in ["latest", "stable", "nightly"] {
+            assert!(is_resolvable_use_version(channel));
+        }
+        assert!(is_resolvable_use_version("1.5.0"));
+        assert!(!is_resolvable_use_version("123abc"));
+        assert!(!is_resolvable_use_version("nightly-abc123"));
+        assert!(!is_resolvable_use_version("foundry-rs-pr-1"));
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -581,7 +581,16 @@ pub(crate) fn list(config: &Config) -> Result<()> {
 
 /// Resolves channels and semver versions to a release tag; activates any other
 /// value verbatim, so `--use 123abc` looks up `123abc` rather than `v123abc`.
-pub(crate) async fn use_version_resolved(config: &Config, repo: &str, version: &str) -> Result<()> {
+///
+/// Without an explicit `--repo`, a version not found under the default repo is
+/// looked up across all installed repos, keeping `--use <name>` working for
+/// custom-repo builds under `versions/<owner>/<repo>/`.
+pub(crate) async fn use_version_resolved(
+    config: &Config,
+    repo: &str,
+    version: &str,
+    repo_explicit: bool,
+) -> Result<()> {
     let tag = if is_resolvable_use_version(version) {
         let downloader = Downloader::new()?;
         let (_version, tag) = resolve_version_and_tag(&downloader, repo, version).await?;
@@ -589,7 +598,60 @@ pub(crate) async fn use_version_resolved(config: &Config, repo: &str, version: &
     } else {
         version.to_string()
     };
+
+    if config.version_dir(repo, &tag).is_dir() {
+        return use_version(config, repo, &tag);
+    }
+
+    if !repo_explicit {
+        if let Some(found_repo) = find_unique_repo_for_version(config, &tag)? {
+            return use_version(config, &found_repo, &tag);
+        }
+    }
+
     use_version(config, repo, &tag)
+}
+
+/// Finds the version directory named `version` across all installed repos,
+/// erroring if more than one repo matches.
+fn find_unique_repo_for_version(config: &Config, version: &str) -> Result<Option<String>> {
+    if !config.versions_dir.exists() {
+        return Ok(None);
+    }
+
+    let mut matches = Vec::new();
+    for owner_entry in fs::read_dir(&config.versions_dir)? {
+        let owner_entry = owner_entry?;
+        let owner_path = owner_entry.path();
+        if !owner_path.is_dir() {
+            continue;
+        }
+        let owner = owner_entry.file_name().to_string_lossy().to_string();
+
+        for repo_entry in fs::read_dir(&owner_path)? {
+            let repo_entry = repo_entry?;
+            if !repo_entry.path().is_dir() {
+                continue;
+            }
+            let repo = repo_entry.file_name().to_string_lossy().to_string();
+
+            if config.version_dir(&format!("{owner}/{repo}"), version).is_dir() {
+                matches.push(format!("{owner}/{repo}"));
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matches.remove(0))),
+        _ => {
+            matches.sort();
+            bail!(
+                "version {version} is installed for multiple repos ({}); specify --repo to disambiguate",
+                matches.join(", ")
+            )
+        }
+    }
 }
 
 /// Whether `version` is a channel or semver version that resolves to a tag.

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn run(cli: Cli) -> Result<()> {
 
     if let Some(ref version) = cli.use_version {
         let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
-        return install::use_version_resolved(&config, repo, version).await;
+        return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
     }
 
     if cli.network.is_some() {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -185,6 +185,37 @@ fn use_version_normalizes_bare_semver() {
     }
 }
 
+// `--use` activates a digit-prefixed non-semver name verbatim, without the `v`
+// prefix applied to semver versions.
+#[test]
+fn use_version_digit_prefixed_name_is_literal() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/foundry-rs/foundry/123abc");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    for bin in BINS {
+        let bin_path = version_dir.join(format!("{bin}{EXE_SUFFIX}"));
+        write_fake_bin(&bin_path);
+    }
+
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "123abc"])
+        .assert()
+        .success()
+        .stderr_eq(str![[r#"
+...
+[..]use - [..]
+...
+"#]]);
+
+    for &bin in BINS {
+        let name = format!("{bin}{EXE_SUFFIX}");
+        assert!(foundry_dir.join("bin").join(&name).exists(), "{name} was not activated");
+    }
+}
+
 // On unix, `--use` activates a version by symlinking it into the bin dir.
 #[cfg(unix)]
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -216,6 +216,62 @@ fn use_version_digit_prefixed_name_is_literal() {
     }
 }
 
+// `--use <name>` without `--repo` finds a build installed under a custom repo.
+#[test]
+fn use_version_finds_custom_repo_without_repo_flag() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/someone/foundry/someone-branch-x");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    for bin in BINS {
+        let bin_path = version_dir.join(format!("{bin}{EXE_SUFFIX}"));
+        write_fake_bin(&bin_path);
+    }
+
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "someone-branch-x"])
+        .assert()
+        .success()
+        .stderr_eq(str![[r#"
+...
+[..]use - [..]
+...
+"#]]);
+
+    for &bin in BINS {
+        let name = format!("{bin}{EXE_SUFFIX}");
+        assert!(foundry_dir.join("bin").join(&name).exists(), "{name} was not activated");
+    }
+}
+
+// `--use <name>` errors when the same version name exists under multiple repos.
+#[test]
+fn use_version_ambiguous_across_repos_errors() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+
+    for repo in ["alice/foundry", "bob/foundry"] {
+        let version_dir = foundry_dir.join(format!("versions/{repo}/shared-name"));
+        std::fs::create_dir_all(&version_dir).unwrap();
+        for bin in BINS {
+            write_fake_bin(&version_dir.join(format!("{bin}{EXE_SUFFIX}")));
+        }
+    }
+
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "shared-name"])
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+...
+[..]installed for multiple repos[..]
+...
+"#]]);
+}
+
 // On unix, `--use` activates a version by symlinking it into the bin dir.
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
Two `--use` fixes for parity with the legacy bash `foundryup`:

- `--use 123abc` now activates the literal name instead of looking for `v123abc`. Only channels (`latest`/`stable`/`nightly`) and real semver get the `v`/tag treatment.
- `--use <name>` finds builds from a custom repo (e.g. `--repo someone/foundry`) without requiring `--repo`, searching all installed repos and erroring if the name is ambiguous.

Part of OSS-334