### PR TITLE
fix: resolve latest/stable via release redirect to avoid API rate limit

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -146,6 +146,27 @@ impl Downloader {
         response.text().await.wrap_err("failed to read response body")
     }
 
+    /// Follows redirects for `url` (via a `HEAD` request, without downloading a
+    /// body) and returns the final effective URL.
+    ///
+    /// Used to resolve the `releases/latest` web redirect to a concrete
+    /// `releases/tag/<tag>` URL without calling the rate-limited GitHub API.
+    /// No token is attached, since `github.com` (unlike `api.github.com`) is not
+    /// subject to the unauthenticated API rate limit.
+    pub(crate) async fn resolve_redirect_url(&self, url: &str) -> Result<String> {
+        let parsed = reqwest::Url::parse(url).wrap_err_with(|| format!("invalid URL {url}"))?;
+        let response = self
+            .client
+            .head(parsed)
+            .send()
+            .await
+            .wrap_err_with(|| format!("failed to HEAD {url}"))?;
+        if !response.status().is_success() {
+            bail!("failed to resolve {url}: HTTP {}", response.status());
+        }
+        Ok(response.url().to_string())
+    }
+
     /// Like [`download_to_string`](Self::download_to_string), but returns
     /// `Ok(None)` when the server responds with HTTP 404 Not Found.
     ///

--- a/src/install.rs
+++ b/src/install.rs
@@ -647,8 +647,9 @@ in your 'PATH' to allow the newly installed version to take precedence!
 /// used for the archive files and asset names.
 ///
 /// The `latest` and `stable` channels are resolved to the newest non-prerelease
-/// tag via the GitHub API. The `nightly` channel is resolved to the newest
-/// nightly release tag. Everything else is normalized offline.
+/// tag via the `releases/latest` web redirect, falling back to the GitHub API.
+/// The `nightly` channel is resolved to the newest nightly release tag.
+/// Everything else is normalized offline.
 pub(crate) async fn resolve_version_and_tag(
     downloader: &Downloader,
     repo: &str,
@@ -669,8 +670,15 @@ pub(crate) async fn resolve_version_and_tag(
     }
 }
 
-/// Fetches the newest non-prerelease release tag for `repo` via the GitHub API.
+/// Fetches the newest non-prerelease release tag for `repo`.
+///
+/// Prefers the `releases/latest` web redirect, which is not subject to the
+/// unauthenticated GitHub API rate limit (the cause of CI `403` failures), and
+/// falls back to the GitHub API when the redirect cannot be resolved.
 async fn fetch_latest_release_tag(downloader: &Downloader, repo: &str) -> Result<String> {
+    if let Some(tag) = fetch_latest_release_tag_via_redirect(downloader, repo).await {
+        return Ok(tag);
+    }
     let url = format!("https://api.github.com/repos/{repo}/releases/latest");
     let body = downloader
         .download_to_string(&url)
@@ -682,6 +690,33 @@ async fn fetch_latest_release_tag(downloader: &Downloader, repo: &str) -> Result
         Some(tag) => Ok(tag.to_string()),
         None => bail!("could not find a latest release tag for {repo}"),
     }
+}
+
+/// Resolves the latest release tag by following the `releases/latest` web
+/// redirect and reading the tag from the final `releases/tag/<tag>` URL.
+///
+/// Returns `None` (so the caller falls back to the API) when the redirect cannot
+/// be resolved or the final URL does not yield a valid tag.
+async fn fetch_latest_release_tag_via_redirect(
+    downloader: &Downloader,
+    repo: &str,
+) -> Option<String> {
+    let url = format!("https://github.com/{repo}/releases/latest");
+    let final_url = downloader.resolve_redirect_url(&url).await.ok()?;
+    tag_from_release_url(&final_url)
+}
+
+/// Extracts and validates a release tag from a `.../releases/tag/<tag>` URL.
+///
+/// Returns `None` for any URL that is not a tag URL or whose tag is not a
+/// plausible version tag: it must look like `v<digit>...` and contain only
+/// `[A-Za-z0-9._-]`, so a trailing slash, query, or fragment is rejected.
+fn tag_from_release_url(url: &str) -> Option<String> {
+    let (_, tag) = url.rsplit_once("/releases/tag/")?;
+    let valid = tag.starts_with('v')
+        && tag.as_bytes().get(1).is_some_and(u8::is_ascii_digit)
+        && tag.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    valid.then(|| tag.to_string())
 }
 
 /// Fetches the newest nightly release tag for `repo` via the GitHub API.
@@ -821,6 +856,46 @@ mod tests {
         let err = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap_err();
 
         assert!(err.to_string().contains("could not find a nightly release tag"));
+    }
+
+    #[test]
+    fn tag_from_release_url_extracts_valid_tag() {
+        // The `releases/latest` redirect lands on a concrete tag page.
+        assert_eq!(
+            tag_from_release_url("https://github.com/foundry-rs/foundry/releases/tag/v1.7.1"),
+            Some("v1.7.1".to_string())
+        );
+        // `-` and `.` are allowed (e.g. release candidates).
+        assert_eq!(
+            tag_from_release_url("https://github.com/foundry-rs/foundry/releases/tag/v1.0.0-rc.1"),
+            Some("v1.0.0-rc.1".to_string())
+        );
+    }
+
+    #[test]
+    fn tag_from_release_url_rejects_non_tag_or_invalid() {
+        // Redirect did not move to a tag page (e.g. landed back on `latest`).
+        assert_eq!(
+            tag_from_release_url("https://github.com/foundry-rs/foundry/releases/latest"),
+            None
+        );
+        // Tag is not a plausible version (must start with `v<digit>`).
+        assert_eq!(
+            tag_from_release_url(
+                "https://github.com/foundry-rs/foundry/releases/tag/not-a-version"
+            ),
+            None
+        );
+        // A trailing slash introduces a disallowed character.
+        assert_eq!(
+            tag_from_release_url("https://github.com/foundry-rs/foundry/releases/tag/v1.7.1/"),
+            None
+        );
+        // Empty tag.
+        assert_eq!(
+            tag_from_release_url("https://github.com/foundry-rs/foundry/releases/tag/"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves `latest/stable` tags via the `github.com`/`<repo>`/`releases`/`latest` web redirect instead of the rate-limited GitHub API, falling back to the API if the redirect can't be resolved. 