### PR TITLE
fix: fail --list on broken installs and ignore FOUNDRYUP_JOBS env

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,8 @@ pub(crate) struct Cli {
     pub commit: Option<String>,
 
     /// Number of CPUs to use for building (default: all)
-    #[arg(short = 'j', long, env = "FOUNDRYUP_JOBS", hide_env = true)]
+    // Not bound to `FOUNDRYUP_JOBS`; only the flag is honored.
+    #[arg(short = 'j', long)]
     pub jobs: Option<u32>,
 
     /// Cargo profile to use for building

--- a/src/install.rs
+++ b/src/install.rs
@@ -551,14 +551,17 @@ pub(crate) fn list(config: &Config) -> Result<()> {
 
                     tell!("{owner_name}/{repo_name} {version_name}");
 
+                    // A missing or non-runnable binary is a broken install.
                     for bin in bins {
                         let bin_path = version_path.join(bin_name(bin));
-                        if bin_path.exists() {
-                            match get_bin_version(&bin_path) {
-                                Ok(v) => tell!("- {v}"),
-                                Err(_) => tell!("- {bin} (unknown version)"),
-                            }
-                        }
+                        let v = get_bin_version(&bin_path).wrap_err_with(|| {
+                            format!(
+                                "{owner_name}/{repo_name} {version_name} is broken: \
+                                 failed to run {}",
+                                bin_path.display()
+                            )
+                        })?;
+                        tell!("- {v}");
                     }
                     println!();
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ use config::Config;
 /// Removes empty `FOUNDRYUP_*` variables before clap parses them.
 ///
 /// clap's `env` support captures `Some("")` and parses it as a real value (e.g.
-/// an empty version, or a non-numeric `FOUNDRYUP_JOBS` that fails parsing), so an
-/// empty variable is cleared here and treated as unset.
+/// an empty `FOUNDRYUP_VERSION` treated as a real version), so an empty variable
+/// is cleared here and treated as unset.
 fn clear_empty_foundryup_env() {
     // `vars_os` is a snapshot, so removing during iteration is safe.
     for (key, value) in std::env::vars_os() {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -295,15 +295,14 @@ fn use_version_creates_symlink_on_unix() {
     }
 }
 
-// Empty `FOUNDRYUP_*` env vars are treated as unset, so an empty `FOUNDRYUP_JOBS`
-// must not fail clap's `u32` parsing.
+// Empty `FOUNDRYUP_*` env vars are treated as unset, so an empty numeric var
+// like `FOUNDRYUP_PR` must not fail clap's integer parsing.
 #[test]
 fn empty_foundryup_env_is_ignored() {
     let temp_dir = tempfile::Builder::new().tempdir().unwrap();
 
     foundryup()
         .env("FOUNDRY_DIR", temp_dir.path().join(".foundry"))
-        .env("FOUNDRYUP_JOBS", "")
         .env("FOUNDRYUP_VERSION", "")
         .env("FOUNDRYUP_PR", "")
         .arg("--list")
@@ -331,12 +330,34 @@ fn list_writes_to_stdout() {
     std::fs::create_dir_all(&version_dir).unwrap();
 
     for bin in BINS {
-        std::fs::write(version_dir.join(format!("{bin}{EXE_SUFFIX}")), "fake binary").unwrap();
+        write_fake_bin(&version_dir.join(format!("{bin}{EXE_SUFFIX}")));
     }
 
     foundryup().env("FOUNDRY_DIR", &foundry_dir).arg("--list").assert().success().stdout_eq(str![
         [r#"
 foundryup: foundry-rs/foundry v1.0.0
+...
+"#]
+    ]);
+}
+
+// A version directory missing a binary fails the listing.
+#[test]
+fn list_fails_on_broken_install() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let version_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.0.0");
+    std::fs::create_dir_all(&version_dir).unwrap();
+
+    // Install all but the last binary, leaving the version incomplete.
+    for bin in &BINS[..BINS.len() - 1] {
+        write_fake_bin(&version_dir.join(format!("{bin}{EXE_SUFFIX}")));
+    }
+
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).arg("--list").assert().failure().stderr_eq(str![
+        [r#"
+...
+[..]is broken: failed to run [..]
 ...
 "#]
     ]);
@@ -354,7 +375,7 @@ fn migrate_legacy_versions() {
     for version in ["nightly", "stable"] {
         for bin in BINS {
             let bin_path = versions_dir.join(version).join(format!("{bin}{EXE_SUFFIX}"));
-            std::fs::write(&bin_path, "fake binary").unwrap();
+            write_fake_bin(&bin_path);
         }
     }
 


### PR DESCRIPTION
- `--list` now fails when an installed version directory is missing or can't run one of its binaries (previously skipped/printed "unknown version"). The no-versions-dir fallback stays tolerant, so `--list` on a fresh system still succeeds.
- `--jobs` is no longer bound to `FOUNDRYUP_JOBS`; an inherited env var is ignored and only the flag is honored.

Part of OSS-334