### PR TITLE
fix: default Linux to glibc artifact

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 #[cfg(test)]
 use snapbox as _;
 
-use clap::Parser;
+use clap::{ArgMatches, CommandFactory, FromArgMatches};
 use eyre::Result;
 use std::sync::Arc;
 
@@ -52,14 +52,41 @@ fn main() -> Result<()> {
         .with_target(false)
         .init();
 
-    let cli = Cli::parse();
+    let matches = Cli::command().get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(e) => e.exit(),
+    };
+    let action = first_action(&matches);
 
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
-    rt.block_on(run(cli))
+    rt.block_on(run(cli, action))
 }
 
-async fn run(cli: Cli) -> Result<()> {
+/// The mutually exclusive actions that run instead of an install.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Action {
+    Update,
+    List,
+    Use,
+}
+
+/// Returns whichever of `--update`/`--list`/`--use` appears earliest on the
+/// command line, so the first one given wins when several are passed together.
+fn first_action(matches: &ArgMatches) -> Option<Action> {
+    // `index_of` reports a position even for absent boolean flags (they default
+    // to `false`), so only consider flags actually passed on the command line.
+    let on_cli = |id| matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine);
+    [("update", Action::Update), ("list", Action::List), ("use_version", Action::Use)]
+        .into_iter()
+        .filter(|(id, _)| on_cli(id))
+        .filter_map(|(id, action)| matches.index_of(id).map(|i| (i, action)))
+        .min_by_key(|(i, _)| *i)
+        .map(|(_, action)| action)
+}
+
+async fn run(cli: Cli, action: Option<Action>) -> Result<()> {
     // Handle --completions first (no banner, no config needed)
     if let Some(shell) = cli.completions {
         cli::print_completions(shell);
@@ -68,20 +95,24 @@ async fn run(cli: Cli) -> Result<()> {
 
     let config = Arc::new(Config::new()?);
 
-    if cli.update {
+    if action == Some(Action::Update) {
         return self_update::run(&config).await;
     }
 
     config.migrate_legacy_versions()?;
 
     // `--list`/`--use` run offline: no update check or banner.
-    if cli.list {
-        return install::list(&config);
-    }
-
-    if let Some(ref version) = cli.use_version {
-        let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
-        return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
+    match action {
+        Some(Action::List) => return install::list(&config),
+        Some(Action::Use) => {
+            // `--use` always carries a version value, so this is set when the
+            // use action is selected.
+            let version = cli.use_version.as_deref().unwrap_or_default();
+            let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
+            return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
+        }
+        // `Update` is handled above; `None` falls through to install.
+        Some(Action::Update) | None => {}
     }
 
     if cli.network.is_some() {
@@ -179,4 +210,31 @@ macro_rules! warn {
     ($($arg:tt)*) => {
         eprintln!("foundryup: warning: {}", format_args!($($arg)*))
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first(args: &[&str]) -> Option<Action> {
+        let matches = Cli::command().get_matches_from(args);
+        first_action(&matches)
+    }
+
+    #[test]
+    fn first_action_is_earliest_on_command_line() {
+        // The earliest of --update/--list/--use wins, regardless of arg order.
+        assert_eq!(first(&["foundryup", "--list", "--update"]), Some(Action::List));
+        assert_eq!(first(&["foundryup", "--update", "--list"]), Some(Action::Update));
+        assert_eq!(first(&["foundryup", "--use", "v1", "--list"]), Some(Action::Use));
+        assert_eq!(first(&["foundryup", "--list", "--use", "v1"]), Some(Action::List));
+        assert_eq!(first(&["foundryup", "--update", "--use", "v1"]), Some(Action::Update));
+        assert_eq!(first(&["foundryup", "--use", "v1", "--update"]), Some(Action::Use));
+        // The `--use=v1` form indexes its value the same as `--use v1`.
+        assert_eq!(first(&["foundryup", "--use=v1", "--list"]), Some(Action::Use));
+        assert_eq!(first(&["foundryup", "--list", "--use=v1"]), Some(Action::List));
+        // No action flag falls through to a normal install.
+        assert_eq!(first(&["foundryup", "-i", "1.2.3"]), None);
+        assert_eq!(first(&["foundryup"]), None);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 #[cfg(test)]
 use snapbox as _;
 
-use clap::{ArgMatches, CommandFactory, FromArgMatches};
+use clap::Parser;
 use eyre::Result;
 use std::sync::Arc;
 
@@ -52,41 +52,14 @@ fn main() -> Result<()> {
         .with_target(false)
         .init();
 
-    let matches = Cli::command().get_matches();
-    let cli = match Cli::from_arg_matches(&matches) {
-        Ok(cli) => cli,
-        Err(e) => e.exit(),
-    };
-    let action = first_action(&matches);
+    let cli = Cli::parse();
 
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
-    rt.block_on(run(cli, action))
+    rt.block_on(run(cli))
 }
 
-/// The mutually exclusive actions that run instead of an install.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Action {
-    Update,
-    List,
-    Use,
-}
-
-/// Returns whichever of `--update`/`--list`/`--use` appears earliest on the
-/// command line, so the first one given wins when several are passed together.
-fn first_action(matches: &ArgMatches) -> Option<Action> {
-    // `index_of` reports a position even for absent boolean flags (they default
-    // to `false`), so only consider flags actually passed on the command line.
-    let on_cli = |id| matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine);
-    [("update", Action::Update), ("list", Action::List), ("use_version", Action::Use)]
-        .into_iter()
-        .filter(|(id, _)| on_cli(id))
-        .filter_map(|(id, action)| matches.index_of(id).map(|i| (i, action)))
-        .min_by_key(|(i, _)| *i)
-        .map(|(_, action)| action)
-}
-
-async fn run(cli: Cli, action: Option<Action>) -> Result<()> {
+async fn run(cli: Cli) -> Result<()> {
     // Handle --completions first (no banner, no config needed)
     if let Some(shell) = cli.completions {
         cli::print_completions(shell);
@@ -95,24 +68,20 @@ async fn run(cli: Cli, action: Option<Action>) -> Result<()> {
 
     let config = Arc::new(Config::new()?);
 
-    if action == Some(Action::Update) {
+    if cli.update {
         return self_update::run(&config).await;
     }
 
     config.migrate_legacy_versions()?;
 
     // `--list`/`--use` run offline: no update check or banner.
-    match action {
-        Some(Action::List) => return install::list(&config),
-        Some(Action::Use) => {
-            // `--use` always carries a version value, so this is set when the
-            // use action is selected.
-            let version = cli.use_version.as_deref().unwrap_or_default();
-            let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
-            return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
-        }
-        // `Update` is handled above; `None` falls through to install.
-        Some(Action::Update) | None => {}
+    if cli.list {
+        return install::list(&config);
+    }
+
+    if let Some(ref version) = cli.use_version {
+        let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
+        return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
     }
 
     if cli.network.is_some() {
@@ -210,31 +179,4 @@ macro_rules! warn {
     ($($arg:tt)*) => {
         eprintln!("foundryup: warning: {}", format_args!($($arg)*))
     };
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn first(args: &[&str]) -> Option<Action> {
-        let matches = Cli::command().get_matches_from(args);
-        first_action(&matches)
-    }
-
-    #[test]
-    fn first_action_is_earliest_on_command_line() {
-        // The earliest of --update/--list/--use wins, regardless of arg order.
-        assert_eq!(first(&["foundryup", "--list", "--update"]), Some(Action::List));
-        assert_eq!(first(&["foundryup", "--update", "--list"]), Some(Action::Update));
-        assert_eq!(first(&["foundryup", "--use", "v1", "--list"]), Some(Action::Use));
-        assert_eq!(first(&["foundryup", "--list", "--use", "v1"]), Some(Action::List));
-        assert_eq!(first(&["foundryup", "--update", "--use", "v1"]), Some(Action::Update));
-        assert_eq!(first(&["foundryup", "--use", "v1", "--update"]), Some(Action::Use));
-        // The `--use=v1` form indexes its value the same as `--use v1`.
-        assert_eq!(first(&["foundryup", "--use=v1", "--list"]), Some(Action::Use));
-        assert_eq!(first(&["foundryup", "--list", "--use=v1"]), Some(Action::List));
-        // No action flag falls through to a normal install.
-        assert_eq!(first(&["foundryup", "-i", "1.2.3"]), None);
-        assert_eq!(first(&["foundryup"]), None);
-    }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -10,8 +10,10 @@ pub(crate) enum Platform {
 
 impl Platform {
     pub(crate) fn detect() -> Result<Self> {
+        // Linux defaults to the glibc `linux` artifact; the `alpine` (musl)
+        // build is opt-in via `--platform`.
         if cfg!(target_os = "linux") {
-            if is_musl() { Ok(Self::Alpine) } else { Ok(Self::Linux) }
+            Ok(Self::Linux)
         } else if cfg!(target_os = "macos") {
             Ok(Self::Darwin)
         } else if cfg!(target_os = "windows") {
@@ -105,17 +107,6 @@ impl Target {
     }
 }
 
-fn is_musl() -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        std::fs::read_to_string("/etc/os-release")
-            .map(|s| s.to_lowercase().contains("alpine"))
-            .unwrap_or(false)
-    }
-    #[cfg(not(target_os = "linux"))]
-    false
-}
-
 fn is_rosetta() -> bool {
     #[cfg(target_os = "macos")]
     {
@@ -159,5 +150,22 @@ mod tests {
         if !super::is_rosetta() {
             assert_eq!(Arch::from_str("x86_64"), Arch::Amd64);
         }
+    }
+
+    // Default platform on Linux is `linux`, even for musl/Alpine targets.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_default_platform_is_linux() {
+        let target = Target::detect(None, Some("x86_64")).unwrap();
+        assert_eq!(target.platform, Platform::Linux);
+        assert_eq!(target.platform.as_str(), "linux");
+    }
+
+    // The Alpine/musl artifact is opt-in via `--platform alpine` / FOUNDRYUP_PLATFORM.
+    #[test]
+    fn alpine_override_still_selects_alpine() {
+        let target = Target::detect(Some("alpine"), Some("x86_64")).unwrap();
+        assert_eq!(target.platform, Platform::Alpine);
+        assert_eq!(target.platform.as_str(), "alpine");
     }
 }

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{Config, FOUNDRYUP_REPO, VERSION},
     download::Downloader,
-    platform::Target,
+    platform::{Arch, Platform},
     say,
 };
 use eyre::{Result, WrapErr};
@@ -27,12 +27,17 @@ pub(crate) async fn run(config: &Config) -> Result<()> {
     say!("downloading foundryup v{new_version}...");
 
     let downloader = Downloader::new()?;
-    let target = Target::detect(None, None)?;
-    let archive_name = format!(
-        "foundryup_{platform}_{arch}",
-        platform = target.platform.as_str(),
-        arch = target.arch.as_str()
-    );
+    // The replacement binary must match this binary's own libc, so a musl build
+    // updates from the `alpine` artifact. This differs from the install target,
+    // which mirrors the legacy installer and defaults Linux to the glibc build.
+    let platform = if cfg!(all(target_os = "linux", target_env = "musl")) {
+        Platform::Alpine
+    } else {
+        Platform::detect()?
+    };
+    let arch = Arch::detect();
+    let archive_name =
+        format!("foundryup_{platform}_{arch}", platform = platform.as_str(), arch = arch.as_str());
 
     let download_url = format!(
         "https://github.com/{FOUNDRYUP_REPO}/releases/download/v{new_version}/{archive_name}"


### PR DESCRIPTION
- Linux installs default to the glibc `linux` artifact; `alpine` (musl) is opt-in via --platform. Self-update still fetches the musl binary when built for musl.

Part of OSS-334