### PR TITLE
fix: treat empty CLI option values as unset

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,31 @@ pub(crate) struct Cli {
     pub version_flag: Option<bool>,
 }
 
+impl Cli {
+    /// Treats an explicit empty option value (e.g. `--repo ""` or `-i ""`) as
+    /// unset so it falls back to its default, matching the shell installer where
+    /// empty variables are defaulted via `${VAR:-default}` / `-n` / `-z` checks.
+    ///
+    /// `--use` is intentionally excluded: an empty value there is an error ("no
+    /// version provided"), not a default. `--path` needs no handling because clap
+    /// already rejects an empty path value.
+    pub(crate) fn clear_empty_values(&mut self) {
+        for opt in [
+            &mut self.repo,
+            &mut self.branch,
+            &mut self.version,
+            &mut self.commit,
+            &mut self.arch,
+            &mut self.platform,
+            &mut self.network,
+        ] {
+            if opt.as_deref() == Some("") {
+                *opt = None;
+            }
+        }
+    }
+}
+
 pub(crate) fn print_completions(shell: clap_complete::Shell) {
     clap_complete::generate(shell, &mut Cli::command(), "foundryup", &mut std::io::stdout());
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub(crate) struct Cli {
     pub list: bool,
 
     /// Use a specific installed version
-    #[arg(short = 'u', long = "use", value_name = "VERSION")]
+    #[arg(short = 'u', long = "use", value_name = "VERSION", value_parser = parse_use_version)]
     pub use_version: Option<String>,
 
     /// Build and install a local repository
@@ -95,8 +95,9 @@ impl Cli {
     /// empty variables are defaulted via `${VAR:-default}` / `-n` / `-z` checks.
     ///
     /// `--use` is intentionally excluded: an empty value there is an error ("no
-    /// version provided"), not a default. `--path` needs no handling because clap
-    /// already rejects an empty path value.
+    /// version provided"), not a default, and is rejected at parse time by
+    /// [`parse_use_version`]. `--path` needs no handling because clap already
+    /// rejects an empty path value.
     pub(crate) fn clear_empty_values(&mut self) {
         for opt in [
             &mut self.repo,
@@ -112,6 +113,12 @@ impl Cli {
             }
         }
     }
+}
+
+/// Rejects an empty `--use` value at parse time, preserving the legacy shell
+/// installer's "no version provided" error message.
+fn parse_use_version(s: &str) -> Result<String, String> {
+    if s.is_empty() { Err("no version provided".to_string()) } else { Ok(s.to_string()) }
 }
 
 pub(crate) fn print_completions(shell: clap_complete::Shell) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,8 @@ fn main() -> Result<()> {
         .with_target(false)
         .init();
 
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+    cli.clear_empty_values();
 
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
@@ -80,6 +81,11 @@ async fn run(cli: Cli) -> Result<()> {
     }
 
     if let Some(ref version) = cli.use_version {
+        // An empty `--use` value is an error, not a default (matching the shell
+        // installer); `Cli::clear_empty_values` deliberately leaves it untouched.
+        if version.is_empty() {
+            eyre::bail!("no version provided");
+        }
         let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
         return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,8 @@ async fn run(cli: Cli) -> Result<()> {
     }
 
     if let Some(ref version) = cli.use_version {
-        // An empty `--use` value is an error, not a default (matching the shell
-        // installer); `Cli::clear_empty_values` deliberately leaves it untouched.
-        if version.is_empty() {
-            eyre::bail!("no version provided");
-        }
+        // An empty `--use` value is rejected at parse time by `parse_use_version`, so `version` is
+        // always non-empty here.
         let repo = cli.repo.as_deref().unwrap_or(config.network.repo);
         return install::use_version_resolved(&config, repo, version, cli.repo.is_some()).await;
     }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -139,6 +139,41 @@ For more information, try '--help'.
 "#]]);
 }
 
+// An empty `--use` value is rejected, not defaulted (matching the shell installer).
+#[test]
+fn use_empty_version_errors() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+
+    foundryup()
+        .env("FOUNDRY_DIR", temp_dir.path().join(".foundry"))
+        .args(["--use", ""])
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+...
+[..]no version provided[..]
+...
+"#]]);
+}
+
+// An empty option value (here `--repo ""`) is treated as unset and falls back to
+// its default, so activation looks under the default `foundry-rs/foundry` repo.
+#[test]
+fn empty_repo_falls_back_to_default() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+
+    foundryup()
+        .env("FOUNDRY_DIR", temp_dir.path().join(".foundry"))
+        .args(["--repo", "", "--use", "nonexistent-version"])
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+...
+[..]version nonexistent-version not installed for foundry-rs/foundry[..]
+...
+"#]]);
+}
+
 #[test]
 fn use_nonexistent_version() {
     let temp_dir = tempfile::Builder::new().tempdir().unwrap();


### PR DESCRIPTION
Explicit empty string flags (e.g. `--repo ""`) were kept as empty values instead of falling back to their defaults. This normalizes empty values for `--repo`, `--branch`, `--version`, `--commit`, `--arch`, `--platform`, and `--network` to unset after parsing.

`--use ""` still errors with "no version provided" since a version is required there.

Part of OSS-334