### PR TITLE
test: link fake foundry binaries

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -16,9 +16,15 @@ fn foundryup() -> Command {
 /// Activation now runs `<bin> -V` and fails if it cannot execute, so test
 /// fixtures need real executables rather than placeholder text. We reuse the
 /// `foundryup` test binary, which exits 0 and prints a version for `-V` on every
-/// platform (and copying it preserves the executable bit on Unix).
+/// platform. Linking avoids copying the debug test binary for every fake bin.
 fn write_fake_bin(path: &std::path::Path) {
-    std::fs::copy(snapbox::cmd::cargo_bin!("foundryup"), path).unwrap();
+    let source = snapbox::cmd::cargo_bin!("foundryup");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, path).unwrap();
+    #[cfg(windows)]
+    std::fs::hard_link(source, path).unwrap();
+    #[cfg(not(any(unix, windows)))]
+    std::fs::copy(source, path).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Avoids copying the debug `foundryup` test binary every time an integration test needs fake `forge`, `cast`, `anvil`, or `chisel` binaries. The fixtures now link to the existing test binary instead: a symlink on Unix, where hard links can fail across filesystems, and a hard link on Windows.

On this machine, `perf stat -r 5` for the `use_version_` integration-test group went from 1.814s to 0.635s, and the `list_` group went from 0.368s to 0.026s.
