### PR TITLE
fix: preflight bins before activating

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -699,19 +699,24 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         bail!("version {version} not installed for {repo}");
     }
 
-    // Preflight all bins before mutating, so a missing one can't leave a mix of
-    // old and new binaries active.
+    // Preflight all bins before mutating: prove each one exists and runs the same
+    // semantic check activation relies on, so neither a missing nor a broken
+    // binary can leave a mix of old and new binaries active.
+    let mut new_versions = Vec::with_capacity(config.network.bins.len());
     for bin in config.network.bins {
         let src = version_dir.join(bin_name(bin));
         if !src.is_file() {
             bail!("binary {bin} not found in version {version} at {}", src.display());
         }
+        let v = get_bin_version(&src)
+            .wrap_err_with(|| format!("failed to run {bin} in version {version}"))?;
+        new_versions.push(v);
     }
 
     crate::process::check_bins_in_use(config)?;
     fs::create_dir_all(&config.bin_dir)?;
 
-    for bin in config.network.bins {
+    for (bin, v) in config.network.bins.iter().zip(new_versions) {
         let bin_name = bin_name(bin);
         let src = version_dir.join(&bin_name);
         let dest = config.bin_path(bin);
@@ -725,8 +730,6 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         #[cfg(not(unix))]
         fs::copy(&src, &dest)?;
 
-        let v = get_bin_version(&dest)
-            .wrap_err_with(|| format!("failed to run {bin} after activating version {version}"))?;
         match old_version {
             Some(old) if old != v => say!("use - {v} (from {old})"),
             _ => say!("use - {v}"),

--- a/src/install.rs
+++ b/src/install.rs
@@ -699,6 +699,15 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         bail!("version {version} not installed for {repo}");
     }
 
+    // Preflight all bins before mutating, so a missing one can't leave a mix of
+    // old and new binaries active.
+    for bin in config.network.bins {
+        let src = version_dir.join(bin_name(bin));
+        if !src.is_file() {
+            bail!("binary {bin} not found in version {version} at {}", src.display());
+        }
+    }
+
     crate::process::check_bins_in_use(config)?;
     fs::create_dir_all(&config.bin_dir)?;
 
@@ -706,10 +715,6 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         let bin_name = bin_name(bin);
         let src = version_dir.join(&bin_name);
         let dest = config.bin_path(bin);
-
-        if !src.is_file() {
-            bail!("binary {bin} not found in version {version} at {}", src.display());
-        }
 
         let old_version = if dest.exists() { get_bin_version(&dest).ok() } else { None };
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -699,6 +699,8 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         bail!("version {version} not installed for {repo}");
     }
 
+    crate::process::check_bins_in_use(config)?;
+
     // Preflight all bins before mutating: prove each one exists and runs the same
     // semantic check activation relies on, so neither a missing nor a broken
     // binary can leave a mix of old and new binaries active.
@@ -713,7 +715,6 @@ pub(crate) fn use_version(config: &Config, repo: &str, version: &str) -> Result<
         new_versions.push(v);
     }
 
-    crate::process::check_bins_in_use(config)?;
     fs::create_dir_all(&config.bin_dir)?;
 
     for (bin, v) in config.network.bins.iter().zip(new_versions) {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -375,6 +375,53 @@ fn use_version_missing_bin_leaves_previous_active() {
     }
 }
 
+// A `--use` that fails on a broken (present but non-runnable) binary must also
+// leave the previously active version fully active, not a partial switch.
+#[cfg(unix)]
+#[test]
+fn use_version_broken_bin_leaves_previous_active() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let good_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.0.0");
+    let broken_dir = foundry_dir.join("versions/foundry-rs/foundry/v2.0.0");
+    std::fs::create_dir_all(&good_dir).unwrap();
+    std::fs::create_dir_all(&broken_dir).unwrap();
+
+    // v1.0.0 is complete; v2.0.0 has all files but `chisel` is not runnable.
+    for bin in BINS {
+        write_fake_bin(&good_dir.join(format!("{bin}{EXE_SUFFIX}")));
+    }
+    for bin in BINS.iter().filter(|b| **b != "chisel") {
+        write_fake_bin(&broken_dir.join(format!("{bin}{EXE_SUFFIX}")));
+    }
+    // A present-but-non-executable file: exists, but fails to run.
+    std::fs::write(broken_dir.join(format!("chisel{EXE_SUFFIX}")), b"not an executable").unwrap();
+
+    // Activate the good version.
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).args(["--use", "1.0.0"]).assert().success();
+
+    // Attempting to switch to the broken version fails...
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "2.0.0"])
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+...
+[..]failed to run chisel[..]
+...
+"#]]);
+
+    // ...and every active binary must still point at v1.0.0, not a mix.
+    let bin_dir = foundry_dir.join("bin");
+    for &bin in BINS {
+        let active = bin_dir.join(format!("{bin}{EXE_SUFFIX}"));
+        let target = std::fs::read_link(&active)
+            .unwrap_or_else(|e| panic!("{bin} is not an active symlink: {e}"));
+        assert_eq!(target, good_dir.join(format!("{bin}{EXE_SUFFIX}")), "{bin} was switched");
+    }
+}
+
 // On unix, `--use` activates a version by symlinking it into the bin dir.
 #[cfg(unix)]
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -330,6 +330,51 @@ fn use_version_ambiguous_across_repos_errors() {
 "#]]);
 }
 
+// A `--use` that fails on a missing binary must not leave a partially-switched
+// toolchain: the previously active version stays fully active.
+#[cfg(unix)]
+#[test]
+fn use_version_missing_bin_leaves_previous_active() {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let foundry_dir = temp_dir.path().join(".foundry");
+    let good_dir = foundry_dir.join("versions/foundry-rs/foundry/v1.0.0");
+    let broken_dir = foundry_dir.join("versions/foundry-rs/foundry/v2.0.0");
+    std::fs::create_dir_all(&good_dir).unwrap();
+    std::fs::create_dir_all(&broken_dir).unwrap();
+
+    // v1.0.0 is complete; v2.0.0 is missing `chisel`.
+    for bin in BINS {
+        write_fake_bin(&good_dir.join(format!("{bin}{EXE_SUFFIX}")));
+    }
+    for bin in BINS.iter().filter(|b| **b != "chisel") {
+        write_fake_bin(&broken_dir.join(format!("{bin}{EXE_SUFFIX}")));
+    }
+
+    // Activate the good version.
+    foundryup().env("FOUNDRY_DIR", &foundry_dir).args(["--use", "1.0.0"]).assert().success();
+
+    // Attempting to switch to the broken version fails...
+    foundryup()
+        .env("FOUNDRY_DIR", &foundry_dir)
+        .args(["--use", "2.0.0"])
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+...
+[..]binary chisel not found[..]
+...
+"#]]);
+
+    // ...and every active binary must still point at v1.0.0, not a mix.
+    let bin_dir = foundry_dir.join("bin");
+    for &bin in BINS {
+        let active = bin_dir.join(format!("{bin}{EXE_SUFFIX}"));
+        let target = std::fs::read_link(&active)
+            .unwrap_or_else(|e| panic!("{bin} is not an active symlink: {e}"));
+        assert_eq!(target, good_dir.join(format!("{bin}{EXE_SUFFIX}")), "{bin} was switched");
+    }
+}
+
 // On unix, `--use` activates a version by symlinking it into the bin dir.
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
`--use` switched active binaries one at a time, so a version missing a binary left a mix of old and new versions active. Check all bins exist first, then activate.