### PR TITLE
fix: retry missing attestation hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "gzip",
     "stream",
 ] }
-tokio = { version = "1", features = ["rt-multi-thread", "fs", "process", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "fs", "process", "io-util", "time"] }
 futures-util = "0.3"
 
 # cli

--- a/src/download.rs
+++ b/src/download.rs
@@ -16,11 +16,14 @@ const DEFAULT_MAX_RETRIES: u32 = 5;
 /// The script's `FOUNDRYUP_RETRY_DELAY` / `FOUNDRYUP_RETRY_MAX_TIME` are not
 /// supported here: reqwest's retry layer manages its own backoff and does not
 /// expose delay or total-time knobs.
-fn max_retries() -> u32 {
-    std::env::var("FOUNDRYUP_MAX_RETRIES")
-        .ok()
-        .and_then(|v| v.trim().parse().ok())
-        .unwrap_or(DEFAULT_MAX_RETRIES)
+pub(crate) fn max_retries() -> u32 {
+    static CACHE: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("FOUNDRYUP_MAX_RETRIES")
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(DEFAULT_MAX_RETRIES)
+    })
 }
 
 /// Transient HTTP statuses that may recover on retry (e.g. GitHub rate limiting

--- a/src/install.rs
+++ b/src/install.rs
@@ -464,7 +464,7 @@ fn missing_attestation_bins(bins: &[&str], hashes: &HashMap<String, String>) -> 
     bins.iter()
         .filter_map(|bin| {
             let bin_name = bin_name(bin);
-            expected_hash(hashes, bin, &bin_name).is_none().then_some(bin_name)
+            expected_hash(hashes, bin, &bin_name).is_none().then(|| (*bin).to_string())
         })
         .collect()
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1025,6 +1025,7 @@ fn rustflags() -> String {
 mod tests {
     use super::*;
     use base64::Engine;
+    use snapbox::{assert_data_eq, str};
 
     #[test]
     fn latest_nightly_release_tag_selects_newest_published_at() {
@@ -1061,7 +1062,10 @@ mod tests {
 
         let err = latest_nightly_release_tag(json, "foundry-rs/foundry").unwrap_err();
 
-        assert!(err.to_string().contains("could not find a nightly release tag"));
+        assert_data_eq!(
+            err.to_string(),
+            str!["could not find a nightly release tag for foundry-rs/foundry"]
+        );
     }
 
     #[test]
@@ -1238,9 +1242,10 @@ mod tests {
         ]));
 
         let err = parse_attestation_payload(&s).unwrap_err();
-        let err = err.to_string();
-        assert!(err.contains("did not contain any SHA-256 subject hashes"));
-        assert!(err.contains("forge"));
+        assert_data_eq!(
+            err.to_string(),
+            str!["attestation did not contain any SHA-256 subject hashes (subjects: forge)"]
+        );
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -347,7 +347,7 @@ async fn fetch_and_verify_attestation(
         let mut all_match = true;
         for bin in bins {
             let bin_name = bin_name(bin);
-            let expected = expected_hash(&hashes, bin, &bin_name);
+            let expected = expected_hash(&hashes, bin, &bin_name)?;
             let path = version_dir.join(&bin_name);
 
             match expected {
@@ -388,18 +388,18 @@ async fn download_attestation_hashes(
 
     loop {
         let artifact_json = downloader.download_to_string(artifact_url).await?;
-        let hashes = parse_attestation_payload(&artifact_json)?;
-        let missing = missing_attestation_bins(bins, &hashes);
+        let attestation = parse_attestation_payload(&artifact_json)?;
+        let missing = missing_attestation_bins(bins, &attestation.hashes)?;
 
         if missing.is_empty() {
-            return Ok(hashes);
+            return Ok(attestation.hashes);
         }
 
         if attempt == max_attempts {
             bail!(
                 "attestation for {tag} is missing SHA-256 hashes for {} after {max_attempts} attempts; available subjects: {}",
                 missing.join(", "),
-                format_hash_subjects(&hashes)
+                format_subjects(&attestation.subjects)
             );
         }
 
@@ -413,7 +413,12 @@ async fn download_attestation_hashes(
     }
 }
 
-fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
+struct AttestationPayload {
+    hashes: HashMap<String, String>,
+    subjects: Vec<String>,
+}
+
+fn parse_attestation_payload(json: &str) -> Result<AttestationPayload> {
     let parsed: serde_json::Value = serde_json::from_str(json)?;
     let payload_b64 = parsed["dsseEnvelope"]["payload"]
         .as_str()
@@ -437,36 +442,48 @@ fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
         }
     }
 
-    if hashes.is_empty() {
-        bail!(
-            "attestation did not contain any SHA-256 subject hashes (subjects: {})",
-            format_subjects(&subjects)
-        );
-    }
-
-    Ok(hashes)
+    Ok(AttestationPayload { hashes, subjects })
 }
 
 fn expected_hash<'a>(
     hashes: &'a HashMap<String, String>,
     bin: &str,
     bin_name: &str,
-) -> Option<&'a String> {
-    hashes.get(bin).or_else(|| hashes.get(bin_name)).or_else(|| {
-        hashes.iter().find_map(|(subject, hash)| {
+) -> Result<Option<&'a String>> {
+    if let Some(hash) = hashes.get(bin).or_else(|| hashes.get(bin_name)) {
+        return Ok(Some(hash));
+    }
+
+    let matching_subjects = hashes
+        .iter()
+        .filter(|(subject, _)| {
             let basename = attestation_subject_basename(subject);
-            (basename == bin || basename == bin_name).then_some(hash)
+            basename == bin || basename == bin_name
         })
-    })
+        .collect::<Vec<_>>();
+
+    match matching_subjects.as_slice() {
+        [] => Ok(None),
+        [(_, hash)] => Ok(Some(*hash)),
+        _ => bail!(
+            "attestation has ambiguous SHA-256 hash subjects for {bin}: {}",
+            format_subjects(matching_subjects.iter().map(|(subject, _)| subject.as_str()))
+        ),
+    }
 }
 
-fn missing_attestation_bins(bins: &[&str], hashes: &HashMap<String, String>) -> Vec<String> {
-    bins.iter()
-        .filter_map(|bin| {
-            let bin_name = bin_name(bin);
-            expected_hash(hashes, bin, &bin_name).is_none().then(|| (*bin).to_string())
-        })
-        .collect()
+fn missing_attestation_bins(
+    bins: &[&str],
+    hashes: &HashMap<String, String>,
+) -> Result<Vec<String>> {
+    let mut missing = Vec::new();
+    for bin in bins {
+        let bin_name = bin_name(bin);
+        if expected_hash(hashes, bin, &bin_name)?.is_none() {
+            missing.push((*bin).to_string());
+        }
+    }
+    Ok(missing)
 }
 
 fn attestation_subject_basename(subject: &str) -> &str {
@@ -551,7 +568,7 @@ fn verify_installed_binaries(
 
     for bin in config.network.bins {
         let bin_name = bin_name(bin);
-        let expected = expected_hash(hashes, bin, &bin_name);
+        let expected = expected_hash(hashes, bin, &bin_name)?;
         let path = version_dir.join(&bin_name);
 
         match expected {
@@ -1225,13 +1242,13 @@ mod tests {
           }
         }"#;
 
-        let hashes = parse_attestation_payload(s).unwrap();
-        assert!(!hashes.is_empty());
-        assert!(hashes.contains_key("forge"));
+        let attestation = parse_attestation_payload(s).unwrap();
+        assert!(!attestation.hashes.is_empty());
+        assert!(attestation.hashes.contains_key("forge"));
     }
 
     #[test]
-    fn attestation_errors_when_no_sha256_subjects() {
+    fn attestation_parses_subjects_without_sha256_hashes() {
         let s = attestation_json(serde_json::json!([
             {
                 "name": "forge",
@@ -1241,11 +1258,10 @@ mod tests {
             }
         ]));
 
-        let err = parse_attestation_payload(&s).unwrap_err();
-        assert_data_eq!(
-            err.to_string(),
-            str!["attestation did not contain any SHA-256 subject hashes (subjects: forge)"]
-        );
+        let attestation = parse_attestation_payload(&s).unwrap();
+        assert_data_eq!(format_subjects(&attestation.subjects), str!["forge"]);
+        assert!(attestation.hashes.is_empty());
+        assert_eq!(missing_attestation_bins(&["forge"], &attestation.hashes).unwrap(), ["forge"]);
     }
 
     #[test]
@@ -1255,8 +1271,24 @@ mod tests {
             "abc".to_string(),
         )]);
 
-        assert_eq!(expected_hash(&hashes, "forge", "forge").unwrap(), "abc");
-        assert!(missing_attestation_bins(&["forge"], &hashes).is_empty());
+        assert_eq!(expected_hash(&hashes, "forge", "forge").unwrap().unwrap(), "abc");
+        assert!(missing_attestation_bins(&["forge"], &hashes).unwrap().is_empty());
+    }
+
+    #[test]
+    fn attestation_bin_lookup_rejects_ambiguous_path_subjects() {
+        let hashes = HashMap::from([
+            ("darwin/forge".to_string(), "abc".to_string()),
+            ("linux/forge".to_string(), "def".to_string()),
+        ]);
+
+        let err = expected_hash(&hashes, "forge", "forge").unwrap_err();
+        assert_data_eq!(
+            err.to_string(),
+            str![
+                "attestation has ambiguous SHA-256 hash subjects for forge: darwin/forge, linux/forge"
+            ]
+        );
     }
 
     #[test]
@@ -1264,7 +1296,7 @@ mod tests {
         let hashes =
             HashMap::from([("foundry_v1.7.1_linux_amd64.tar.gz".to_string(), "abc".to_string())]);
 
-        let missing = missing_attestation_bins(&["forge", "cast"], &hashes);
+        let missing = missing_attestation_bins(&["forge", "cast"], &hashes).unwrap();
 
         assert_eq!(missing, ["forge", "cast"]);
         assert_eq!(format_hash_subjects(&hashes), "foundry_v1.7.1_linux_amd64.tar.gz");

--- a/src/install.rs
+++ b/src/install.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use eyre::{Result, WrapErr, bail};
 use fs_err as fs;
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, time::Duration};
 
 pub(crate) async fn run(config: &Config, args: &Cli) -> Result<()> {
     config.ensure_dirs()?;
@@ -300,6 +300,11 @@ enum PrebuiltCheck {
     Download(Option<HashMap<String, String>>),
 }
 
+// Missing attestation subjects can come from temporarily stale GitHub/CDN data;
+// keep semantic retries spaced out, but cap the delay so installs fail promptly.
+const ATTESTATION_RETRY_INITIAL_DELAY: Duration = Duration::from_secs(1);
+const ATTESTATION_RETRY_MAX_DELAY: Duration = Duration::from_secs(4);
+
 async fn fetch_and_verify_attestation(
     config: &Config,
     repo: &str,
@@ -385,6 +390,7 @@ async fn download_attestation_hashes(
 ) -> Result<HashMap<String, String>> {
     let max_attempts = max_retries().saturating_add(1);
     let mut attempt = 1;
+    let mut retry_delay = ATTESTATION_RETRY_INITIAL_DELAY;
 
     loop {
         let artifact_json = downloader.download_to_string(artifact_url).await?;
@@ -405,11 +411,14 @@ async fn download_attestation_hashes(
 
         let next_attempt = attempt + 1;
         say!(
-            "attestation for {tag} is missing SHA-256 hashes for {}; retrying attestation download ({}/{max_attempts})",
+            "attestation for {tag} is missing SHA-256 hashes for {}; retrying attestation download in {}s ({}/{max_attempts})",
             missing.join(", "),
+            retry_delay.as_secs(),
             next_attempt
         );
+        tokio::time::sleep(retry_delay).await;
         attempt = next_attempt;
+        retry_delay = (retry_delay * 2).min(ATTESTATION_RETRY_MAX_DELAY);
     }
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::Cli,
     config::Config,
-    download::{Downloader, compute_sha256, extract_tar_gz, extract_zip},
+    download::{Downloader, compute_sha256, extract_tar_gz, extract_zip, max_retries},
     platform::{Platform, Target},
     say, tell, warn,
 };
@@ -339,9 +339,7 @@ async fn fetch_and_verify_attestation(
     say!("found attestation for {tag} version, downloading attestation artifact, checking...");
 
     let artifact_url = format!("{attestation_link}/download");
-    let artifact_json = downloader.download_to_string(&artifact_url).await?;
-
-    let hashes = parse_attestation_payload(&artifact_json)?;
+    let hashes = download_attestation_hashes(downloader, &artifact_url, bins, tag).await?;
 
     let version_dir = config.version_dir(repo, tag);
 
@@ -349,7 +347,7 @@ async fn fetch_and_verify_attestation(
         let mut all_match = true;
         for bin in bins {
             let bin_name = bin_name(bin);
-            let expected = hashes.get(*bin).or_else(|| hashes.get(&bin_name));
+            let expected = expected_hash(&hashes, bin, &bin_name);
             let path = version_dir.join(&bin_name);
 
             match expected {
@@ -379,6 +377,42 @@ async fn fetch_and_verify_attestation(
     Ok(PrebuiltCheck::Download(Some(hashes)))
 }
 
+async fn download_attestation_hashes(
+    downloader: &Downloader,
+    artifact_url: &str,
+    bins: &[&str],
+    tag: &str,
+) -> Result<HashMap<String, String>> {
+    let max_attempts = max_retries().saturating_add(1);
+    let mut attempt = 1;
+
+    loop {
+        let artifact_json = downloader.download_to_string(artifact_url).await?;
+        let hashes = parse_attestation_payload(&artifact_json)?;
+        let missing = missing_attestation_bins(bins, &hashes);
+
+        if missing.is_empty() {
+            return Ok(hashes);
+        }
+
+        if attempt == max_attempts {
+            bail!(
+                "attestation for {tag} is missing SHA-256 hashes for {} after {max_attempts} attempts; available subjects: {}",
+                missing.join(", "),
+                format_hash_subjects(&hashes)
+            );
+        }
+
+        let next_attempt = attempt + 1;
+        say!(
+            "attestation for {tag} is missing SHA-256 hashes for {}; retrying attestation download ({}/{max_attempts})",
+            missing.join(", "),
+            next_attempt
+        );
+        attempt = next_attempt;
+    }
+}
+
 fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
     let parsed: serde_json::Value = serde_json::from_str(json)?;
     let payload_b64 = parsed["dsseEnvelope"]["payload"]
@@ -390,9 +424,13 @@ fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
     let payload_json: serde_json::Value = serde_json::from_slice(&payload_bytes)?;
 
     let mut hashes = HashMap::new();
+    let mut subjects = Vec::new();
 
     if let Some(subject) = payload_json["subject"].as_array() {
         for entry in subject {
+            if let Some(name) = entry["name"].as_str() {
+                subjects.push(name.to_string());
+            }
             if let (Some(name), Some(digest)) =
                 (entry["name"].as_str(), entry["digest"]["sha256"].as_str())
             {
@@ -401,7 +439,55 @@ fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
         }
     }
 
+    if hashes.is_empty() {
+        bail!(
+            "attestation did not contain any SHA-256 subject hashes (subjects: {})",
+            format_subjects(&subjects)
+        );
+    }
+
     Ok(hashes)
+}
+
+fn expected_hash<'a>(
+    hashes: &'a HashMap<String, String>,
+    bin: &str,
+    bin_name: &str,
+) -> Option<&'a String> {
+    hashes.get(bin).or_else(|| hashes.get(bin_name)).or_else(|| {
+        hashes.iter().find_map(|(subject, hash)| {
+            let basename = attestation_subject_basename(subject);
+            (basename == bin || basename == bin_name).then_some(hash)
+        })
+    })
+}
+
+fn missing_attestation_bins(bins: &[&str], hashes: &HashMap<String, String>) -> Vec<String> {
+    bins.iter()
+        .filter_map(|bin| {
+            let bin_name = bin_name(bin);
+            expected_hash(hashes, bin, &bin_name).is_none().then_some(bin_name)
+        })
+        .collect()
+}
+
+fn attestation_subject_basename(subject: &str) -> &str {
+    subject.rsplit(['/', '\\']).find(|part| !part.is_empty()).unwrap_or(subject)
+}
+
+fn format_hash_subjects(hashes: &HashMap<String, String>) -> String {
+    format_subjects(hashes.keys())
+}
+
+fn format_subjects<I, S>(subjects: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut subjects = subjects.into_iter().map(|s| s.as_ref().to_string()).collect::<Vec<_>>();
+    subjects.sort();
+    subjects.dedup();
+    if subjects.is_empty() { "none".to_string() } else { subjects.join(", ") }
 }
 
 async fn download_and_extract(
@@ -463,15 +549,16 @@ fn verify_installed_binaries(
 
     let version_dir = config.version_dir(repo, tag);
     let mut failed = false;
+    let mut missing = Vec::new();
 
     for bin in config.network.bins {
         let bin_name = bin_name(bin);
-        let expected = hashes.get(*bin).or_else(|| hashes.get(&bin_name));
+        let expected = expected_hash(hashes, bin, &bin_name);
         let path = version_dir.join(&bin_name);
 
         match expected {
             None => {
-                say!("no expected hash for {bin}");
+                missing.push(bin_name);
                 failed = true;
             }
             Some(expected_hash) => {
@@ -492,6 +579,11 @@ fn verify_installed_binaries(
                 }
             }
         }
+    }
+
+    if !missing.is_empty() {
+        say!("attestation did not include expected hashes for: {}", missing.join(", "));
+        say!("attestation subjects: {}", format_hash_subjects(hashes));
     }
 
     if failed {
@@ -934,6 +1026,7 @@ fn rustflags() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
 
     #[test]
     fn latest_nightly_release_tag_selects_newest_published_at() {
@@ -1132,6 +1225,52 @@ mod tests {
 
         let hashes = parse_attestation_payload(s).unwrap();
         assert!(!hashes.is_empty());
+        assert!(hashes.contains_key("forge"));
+    }
+
+    #[test]
+    fn attestation_errors_when_no_sha256_subjects() {
+        let s = attestation_json(serde_json::json!([
+            {
+                "name": "forge",
+                "digest": {
+                    "sha512": "abc"
+                }
+            }
+        ]));
+
+        let err = parse_attestation_payload(&s).unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains("did not contain any SHA-256 subject hashes"));
+        assert!(err.contains("forge"));
+    }
+
+    #[test]
+    fn attestation_bin_lookup_accepts_path_subjects() {
+        let hashes = HashMap::from([(
+            "target/x86_64-unknown-linux-gnu/release/forge".to_string(),
+            "abc".to_string(),
+        )]);
+
+        assert_eq!(expected_hash(&hashes, "forge", "forge").unwrap(), "abc");
+        assert!(missing_attestation_bins(&["forge"], &hashes).is_empty());
+    }
+
+    #[test]
+    fn attestation_missing_bins_lists_expected_binary_names() {
+        let hashes =
+            HashMap::from([("foundry_v1.7.1_linux_amd64.tar.gz".to_string(), "abc".to_string())]);
+
+        let missing = missing_attestation_bins(&["forge", "cast"], &hashes);
+
+        assert_eq!(missing, ["forge", "cast"]);
+        assert_eq!(format_hash_subjects(&hashes), "foundry_v1.7.1_linux_amd64.tar.gz");
+    }
+
+    fn attestation_json(subjects: serde_json::Value) -> String {
+        let payload = serde_json::json!({ "subject": subjects }).to_string();
+        let payload = base64::engine::general_purpose::STANDARD.encode(payload);
+        serde_json::json!({ "dsseEnvelope": { "payload": payload } }).to_string()
     }
 
     fn test_config(foundry_dir: &Path) -> Config {

--- a/src/install.rs
+++ b/src/install.rs
@@ -428,12 +428,10 @@ fn parse_attestation_payload(json: &str) -> Result<HashMap<String, String>> {
 
     if let Some(subject) = payload_json["subject"].as_array() {
         for entry in subject {
-            if let Some(name) = entry["name"].as_str() {
-                subjects.push(name.to_string());
-            }
-            if let (Some(name), Some(digest)) =
-                (entry["name"].as_str(), entry["digest"]["sha256"].as_str())
-            {
+            let Some(name) = entry["name"].as_str() else { continue };
+            subjects.push(name.to_string());
+
+            if let Some(digest) = entry["digest"]["sha256"].as_str() {
                 hashes.insert(name.to_string(), digest.to_string());
             }
         }

--- a/tests/it/installer_script.rs
+++ b/tests/it/installer_script.rs
@@ -3,6 +3,8 @@ use std::{
     process::{Command, Stdio},
 };
 
+use snapbox::{assert_data_eq, str};
+
 fn normalize_line_endings(s: &str) -> String {
     s.replace("\r\n", "\n").replace('\r', "")
 }
@@ -43,9 +45,31 @@ fn script_usage_works() {
     let output = run_script_function("usage");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("foundryup-init"), "usage should mention foundryup-init");
-    assert!(stdout.contains("--help"), "usage should mention --help");
-    assert!(stdout.contains("--version"), "usage should mention --version");
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+foundryup-init 2.0.0
+
+The installer for foundryup
+
+Usage: foundryup-init.sh [OPTIONS]
+
+Options:
+  -v, --verbose   Enable verbose output
+  -q, --quiet     Disable progress output
+  -y, --yes       Skip confirmation prompt
+  -f, --force     Skip attestation verification (INSECURE)
+  -h, --help      Print help
+  -V, --version   Print version
+
+All other options are passed to foundryup after installation.
+
+Environment variables:
+  FOUNDRYUP_VERSION              Install a specific version of foundryup
+  FOUNDRYUP_IGNORE_VERIFICATION  Skip attestation verification if set to "true"
+
+"#]]
+    );
 }
 
 #[test]
@@ -59,7 +83,31 @@ fn script_help_flag() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("foundryup-init"));
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+foundryup-init 2.0.0
+
+The installer for foundryup
+
+Usage: foundryup-init.sh [OPTIONS]
+
+Options:
+  -v, --verbose   Enable verbose output
+  -q, --quiet     Disable progress output
+  -y, --yes       Skip confirmation prompt
+  -f, --force     Skip attestation verification (INSECURE)
+  -h, --help      Print help
+  -V, --version   Print version
+
+All other options are passed to foundryup after installation.
+
+Environment variables:
+  FOUNDRYUP_VERSION              Install a specific version of foundryup
+  FOUNDRYUP_IGNORE_VERIFICATION  Skip attestation verification if set to "true"
+
+"#]]
+    );
 }
 
 #[test]
@@ -149,7 +197,7 @@ fn script_check_cmd_exists() {
     let output = run_script_function("check_cmd sh && echo 'found'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("found"));
+    assert_data_eq!(stdout.as_ref(), "found\n");
 }
 
 #[test]
@@ -158,7 +206,7 @@ fn script_check_cmd_not_exists() {
         run_script_function("check_cmd nonexistent_cmd_12345 && echo 'found' || echo 'not'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("not"));
+    assert_data_eq!(stdout.as_ref(), "not\n");
 }
 
 #[test]
@@ -166,7 +214,10 @@ fn script_need_cmd_fails_for_missing() {
     let output = run_script_function("need_cmd nonexistent_cmd_xyz_12345");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("need 'nonexistent_cmd_xyz_12345'"));
+    assert_data_eq!(
+        stderr.as_ref(),
+        "foundryup-init: need 'nonexistent_cmd_xyz_12345' (command not found)\n"
+    );
 }
 
 #[test]
@@ -181,7 +232,7 @@ fn script_assert_nz_success() {
         stdout,
         stderr
     );
-    assert!(stdout.contains("ok"), "stdout missing 'ok': {}", stdout);
+    assert_data_eq!(stdout.as_ref(), "ok\n");
 }
 
 #[test]
@@ -196,7 +247,7 @@ fn script_assert_nz_failure() {
         stdout,
         stderr
     );
-    assert!(stderr.contains("assert_nz test"), "stderr missing 'assert_nz test': {}", stderr);
+    assert_data_eq!(stderr.as_ref(), "foundryup-init: assert_nz test\n");
 }
 
 #[test]
@@ -204,7 +255,7 @@ fn script_say_output() {
     let output = run_script_function("say 'hello world'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("foundryup-init: hello world"));
+    assert_data_eq!(stdout.as_ref(), "foundryup-init: hello world\n");
 }
 
 #[test]
@@ -212,7 +263,7 @@ fn script_downloader_check() {
     let output = run_script_function("downloader --check && echo 'ok'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("ok"));
+    assert_data_eq!(stdout.as_ref(), "ok\n");
 }
 
 #[test]
@@ -220,7 +271,7 @@ fn script_ensure_success() {
     let output = run_script_function("ensure true && echo 'ok'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("ok"));
+    assert_data_eq!(stdout.as_ref(), "ok\n");
 }
 
 #[test]
@@ -228,7 +279,7 @@ fn script_ensure_failure() {
     let output = run_script_function("ensure false");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("command failed"));
+    assert_data_eq!(stderr.as_ref(), "foundryup-init: command failed: false\n");
 }
 
 #[test]
@@ -236,7 +287,7 @@ fn script_ignore_runs_command() {
     let output = run_script_function("ignore echo 'test'");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("test"));
+    assert_data_eq!(stdout.as_ref(), "test\n");
 }
 
 #[test]
@@ -244,7 +295,7 @@ fn script_foundryup_repo_defined() {
     let output = run_script_function(r#"echo "$FOUNDRYUP_REPO""#);
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("foundry-rs/foundryup"));
+    assert_data_eq!(stdout.as_ref(), "foundry-rs/foundryup\n");
 }
 
 #[test]
@@ -260,7 +311,7 @@ echo "$FOUNDRYUP_BIN_DIR"
 "#
     ));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("/tmp/test_home/.foundry/bin"));
+    assert_data_eq!(stdout.as_ref(), "/tmp/test_home/.foundry/bin\n");
 }
 
 #[test]
@@ -424,9 +475,14 @@ fn script_downloads_with_attestation_verification() {
     assert!(foundryup_path.exists(), "foundryup binary should be installed");
 
     let combined = format!("{stdout}{stderr}");
-    assert!(
-        combined.contains("binary verified"),
-        "attestation verification should succeed with 'binary verified ✓'. Output: {combined}"
+    assert_data_eq!(
+        combined,
+        str![[r#"
+...
+[..]foundryup-init: binary verified ✓[..]
+...
+
+"#]]
     );
 
     std::fs::remove_dir_all(&temp_dir).ok();
@@ -453,9 +509,14 @@ fn script_downloads_with_force_skips_attestation() {
     assert!(output.status.success(), "script failed:\nstdout: {stdout}\nstderr: {stderr}");
 
     let combined = format!("{stdout}{stderr}");
-    assert!(
-        combined.contains("skipping attestation verification"),
-        "--force should skip attestation. Output: {combined}"
+    assert_data_eq!(
+        combined,
+        str![[r#"
+...
+[..]foundryup-init: skipping attestation verification (--force or FOUNDRYUP_IGNORE_VERIFICATION set)[..]
+...
+
+"#]]
     );
 
     std::fs::remove_dir_all(&temp_dir).ok();

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,4 +1,4 @@
-use snapbox::{cmd::Command, str};
+use snapbox::{assert_data_eq, cmd::Command, str};
 use std::env::consts::EXE_SUFFIX;
 
 const BINS: &[&str] = &["forge", "cast", "anvil", "chisel"];
@@ -130,7 +130,15 @@ fn completions_bash() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("_foundryup"), "expected _foundryup in completions");
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+...
+_foundryup()[..]
+...
+
+"#]]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This makes foundryup treat an attestation payload that is missing hashes for the configured binaries as a retryable semantic failure, using the same FOUNDRYUP_MAX_RETRIES setting as HTTP retries. If the payload remains unusable, the error now reports which binary hashes were missing and which attestation subjects were present.

It also accepts path-shaped attestation subjects by matching the final path component, so attestations that include target paths can still verify the installed binary names.
